### PR TITLE
[1pt] PR: ESRI CRS's error out 

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v1._____ - 2023-07-24 - [PR#103](https://github.com/NOAA-OWP/ras2fim/pull/103)
+
+Previously, ras2fim could only accommodate projections in the EPSG format. This PR is a quick fix to how the projection is processed to accommodate projection codes in the ESRI format.
+
+### Changes  
+
+- `src/ras2fim.py`: Replaced `CRS.from_epsg` with `CRS.from_string` in order to accommodate ESRI projections.
+- `src/shared_functions.py`: Edited error message for clarity.
+
+<br/><br/>
+
+
 ## v1.13.0 - 2023-07-06 - [PR#93](https://github.com/NOAA-OWP/ras2fim/pull/93)
 
 Add multi processing when calculating `maxments` for each feature ID. 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v1._____ - 2023-07-24 - [PR#103](https://github.com/NOAA-OWP/ras2fim/pull/103)
+## v1.13.1 - 2023-07-24 - [PR#103](https://github.com/NOAA-OWP/ras2fim/pull/103)
 
 Previously, ras2fim could only accommodate projections in the EPSG format. This PR is a quick fix to how the projection is processed to accommodate projection codes in the ESRI format.
 

--- a/src/conflate_hecras_to_nwm.py
+++ b/src/conflate_hecras_to_nwm.py
@@ -484,12 +484,12 @@ def fn_conflate_hecras_to_nwm(str_huc8_arg, str_shp_in_arg, str_shp_out_arg, str
             # Create a shapefile of the intersected points
     
             schema = {'geometry': 'Point', 'properties': {}}
-    
+
             with collection(str_xs_on_feature_id_pt,
                             "w",
                             "ESRI Shapefile",
-                            schema, crs=from_epsg(ble_prj[5:])) as output:
-                # ~~~~~~~~~~~~~~~~~~~~
+                             schema, crs = ble_prj) as output:
+                 # ~~~~~~~~~~~~~~~~~~~~
                 # Slice ble_prj to remove the "epsg:"
                 # ~~~~~~~~~~~~~~~~~~~~
     

--- a/src/ras2fim.py
+++ b/src/ras2fim.py
@@ -368,12 +368,10 @@ def init_and_run_ras2fim(str_huc8_arg,
     ####  Some validation of input, but mostly setting up pathing ######
 
     # -------------------
-    #read RAS models units from both prj file and given EPSG code through -p
-    #below functions involve a series of excpetion checkings
-    epsg_code=int(str_crs_arg.split(':')[1])
-    proj_crs = pyproj.CRS.from_epsg(epsg_code)
-    model_unit=sf.confirm_models_unit(proj_crs,str_ras_path_arg)
-
+    # Read RAS models units from both prj file and given EPSG code through -p
+    # Functions below check for a series of exceptions 
+    proj_crs = pyproj.CRS.from_string(str_crs_arg) 
+    model_unit = sf.confirm_models_unit(proj_crs, str_ras_path_arg)
 
     # -w   (ie 12090301)
     if (len(str_huc8_arg) != 8):

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -145,9 +145,9 @@ def model_unit_from_ras_prj(str_ras_path_arg):
             unit=Units_Found[0]
 
         elif len(set(Units_Found))==2 :
-            raise ModelUnitError("Ras2fim excepts HEC-RAS models with similar unit (either US Customary or "
-                                 "International/Metric). The provided dataset has a mix use of these units. "
-                                 "Verify you HEC-RAS models units and try again. ")
+            raise ModelUnitError("Ras2fim only accepts HEC-RAS models with similar units (either U.S. Customary or "
+                                 "International/Metric). The provided dataset uses a mix of these units. "
+                                 "Verify your HEC-RAS models units and try again.")
 
     except ModelUnitError as e:
         print(e)

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -88,7 +88,7 @@ def model_unit_from_crs(proj_crs):
         unit = proj_crs.axis_info[0].unit_name
         if "foot" in unit:
             unit='feet'
-        elif 'meter' in unit:
+        elif 'metre' in unit:
             unit='meter'
         else:
             raise ModelUnitError("Make sure you have entered a correct projection code.\

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -88,7 +88,7 @@ def model_unit_from_crs(proj_crs):
         unit = proj_crs.axis_info[0].unit_name
         if "foot" in unit:
             unit='feet'
-        elif 'metre' in unit:
+        elif 'meter' in unit:
             unit='meter'
         else:
             raise ModelUnitError("Make sure you have entered a correct projection code.\


### PR DESCRIPTION
Previously, ras2fim could only accommodate projections in the EPSG format. This PR is a quick fix to how the projection is processed to accommodate projection codes in the ESRI format.

### Changes  

- `src/ras2fim.py`: Replaced `CRS.from_epsg` with `CRS.from_string` in order to accommodate ESRI projections.
- `src/shared_functions.py`: Edited error message for clarity.


### Testing

- Tested on HUC 12040101, which uses an ESRI projection. The 'unable to find projection' error no longer occurred after the fix.

### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
