### PR TITLE
[1pt] PR: Fixed rounding issue for meters for rating curves

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v1.16.1 - 2023-08-01 - [PR#124](https://github.com/NOAA-OWP/ras2fim/pull/124)
+
+Precision and rounding were creating a minor problem with an exact match of stage_m and stage_mm (millimeters).   It was a matter of the order of precision versus rounding.
+
+### Changes  
+
+- `src`
+   - `worker_fim_rasters.py`: Now the calcs for stage_m with a precision of 3, then multiply it by 1000, otherwise, precisions is based on 3,048 and not 0.3048.
+
+<br/><br/>
+
 ## v1.16.0 - 2023-07-31 - [PR#115](https://github.com/NOAA-OWP/ras2fim/pull/115)
 
 This PR covers two items, both are pretty small, and a couple bug fixes.

--- a/src/worker_fim_rasters.py
+++ b/src/worker_fim_rasters.py
@@ -247,10 +247,8 @@ def fn_create_rating_curve(list_int_step_flows_fn,
         # we need to add meter columns and convert feet to metric
         df_rating_curve["discharge_cms"] = np.round(df_rating_curve["discharge_cfs"].values * 0.3048 ** 3, 3)
         df_rating_curve["stage_m"] = np.round(df_rating_curve["stage_ft"].values * 0.3048, 3)
-        df_rating_curve["stage_mm"] = np.round(df_rating_curve["stage_ft"].values * 0.3048 * 1000, 3)
-    else:
-        df_rating_curve["stage_mm"] = df_rating_curve["stage_m"] * 1000 # change to millimeters
-        
+
+    df_rating_curve["stage_mm"] = df_rating_curve["stage_m"] * 1000 # change to millimeters        
     df_rating_curve["stage_mm"] = df_rating_curve["stage_mm"].astype('int')
 
     str_csv_path = str_rating_path_to_create + '\\' + str_feature_id_fn + '_rating_curve.csv'


### PR DESCRIPTION
Precision and rounding were creating a minor problem with an exact match of stage_m and stage_mm (millimeters).   It was a matter of the order of precision versus rounding.

### Changes  

- `src`
   - `worker_fim_rasters.py`: Now the calcs for stage_m with a precision of 3, then multiply it by 1000, otherwise, precisions is based on 3,048 and not 0.3048.

### Testing

Notice: stage_m matches stage_mm values. and at stage_m being 3.048 means 3048 for stage_mm which is correct values.
![image](https://github.com/NOAA-OWP/ras2fim/assets/90854818/fe7ef1e2-dc86-4fa4-b7f6-1102f356ec92)


### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x]  New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
