### PR TITLE
[1pt] PR: Remove mentions of EPSG from reformat_ras_rating_curve.py

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v1._____ - 2023-08-07 - [PR#132](https://github.com/NOAA-OWP/ras2fim/pull/132)
+
+A quick fix to remove mentions of EPSG from `reformat_ras_rating_curve.py`.  Using EPSG-specific geopandas commands was causing HUC 12040101 to error out (since this HUC uses an ESRI projection code). Generalizing the CRS handling from `EPSG=` to `crs=` seems to fix the issue. 
+
+### Changes  
+
+- `src/reformat_ras_rating_curve.py`: Generalized CRS handling from `EPSG=` to `crs=` 
+
+<br/><br/>
+
 ## v1.18.0 - 2023-08-03 - [PR#128](https://github.com/NOAA-OWP/ras2fim/pull/128)
 
 Rating curves were erroring out as a mismatch of number of items in a column with the wse (Water Surface Elevation) data list having one extra element in some scenarios.

--- a/src/reformat_ras_rating_curve.py
+++ b/src/reformat_ras_rating_curve.py
@@ -256,7 +256,7 @@ def dir_reformat_ras_rc(dir, input_folder_path, intermediate_filename,
             proj_crs = line.split('==')[1].strip()                
 
     # Remove 'EPSG:' label if it is present ( ## proj_crs replaced str_epsg_raster)
-    proj_crs = proj_crs.lower().replace("epsg:", "")
+    # proj_crs = proj_crs.lower().replace("epsg:", "")
 
     # Standardize the model unit and output unit
     model_unit = get_unit_from_string(model_unit)
@@ -502,8 +502,8 @@ def dir_reformat_ras_rc(dir, input_folder_path, intermediate_filename,
         midpoints_gdf = gpd.GeoDataFrame(midpoints_df, geometry='geometry')
 
         # Make sure the rasters and points are in the same projection so that the extract can work properly
-        midpoints_gdf = midpoints_gdf.set_crs('EPSG:4326') # set the correct projection 
-        midpoints_gdf = midpoints_gdf.to_crs(epsg=proj_crs) # reproject to same as terrain
+        midpoints_gdf = midpoints_gdf.set_crs('EPSG:4326') # set the correct projection ## TODO: Confirm that this is OK in the longterm
+        midpoints_gdf = midpoints_gdf.to_crs(crs=proj_crs) # reproject to same as terrain
         
         # Extract elevation value from terrain raster
         raw_elev_list = []


### PR DESCRIPTION
A quick fix to remove mentions of EPSG from `reformat_ras_rating_curve.py`.  Using EPSG-specific geopandas commands was causing HUC 12040101 to error out (since this HUC uses an ESRI projection code). Generalizing the CRS handling from `EPSG=` to `crs=` seems to fix the issue. 

### Changes  

- `src/reformat_ras_rating_curve.py`: Generalized CRS handling from `EPSG=` to `crs=` 

### Testing

- Tested on 12040101 
- Should also be tested on 12090301


### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
