### PR TITLE
[3pt] PR: New tool: ras_unit_to_s3

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v1.x.x - 2023-09-28 - [PR#166](https://github.com/NOAA-OWP/ras2fim/pull/166)
+## v1.29.0 - 2023-09-29 - [PR#166](https://github.com/NOAA-OWP/ras2fim/pull/166)
 
 This PR includes a new tool that can take a ras2fim unit output folder and upload it to S3. During that upload processes, it checks the s3 `output_ras2fim` folder to look for folders already share the same huc and crs values. A folder may/may not pre-exist that matches the huc and crs but may/may not share a date.  A new master file called `ras_output_tracker.csv` exists now in the s3 `output_ras2fim` folder which tracks all folders uploaded, moved to archive, and overwritten. All activities done by the new `ras_unit_to_s3.py` update this new master copy in S3.
 
@@ -47,6 +47,57 @@ Other small fixes include:
      - `get_models_by_catalog.py:  renamed a page level function name. Changed to UTC time. Added "3_" as a new skip filter for downloading model folders. Removed code to validate incoming CRS value to use the `shared_validators.py` version.
 
 <br/><br/>
+
+
+## v1.28.0 - 2023-09-29 - [PR#168](https://github.com/NOAA-OWP/ras2fim/pull/168)
+
+Errors were being thrown by `conflate_hecras_to_nwm` as it iterated through a shape layer, with some records being linestrings and others being multilinestrings.  Upon closer examination, it was doing some unnecessary "simplifying".  Cleaning that up took care of it, as it did not need to attempt to split a multi line string to independent segments to run simplify.
+
+Also took care of a couple of other tidbits that I ran into:
+1) During Step 2 (`create_shapes_from_hecras`), the hecras engine would throw errors saying if it could not find some key input files. This has now been fixed. Note: Later, this should be logged.
+eg. 
+![image](https://github.com/NOAA-OWP/ras2fim/assets/90854818/63e12a0f-78bd-4a87-afab-9c79e450bd3b)
+
+2) Added a duration timer to calibration `reformat_ras_rating_curves.py`
+
+### Changes  
+- `src`
+    - `conflate_hecras_to_nwm.py`:  simplified the code which uses the shapely "simplify" calls.
+    - `create_shapes_from_hecras.py`:  added a test to ensure the ras_project_path (file) exists. 
+    - `ras2fim.py`:  small text change.
+    - `reformat_ras_rating_curve.py`:  added a duration output system.
+
+<br/><br/>
+
+
+## v1.27.1 - 2023-09-28 - [PR#176](https://github.com/NOAA-OWP/ras2fim/pull/176)
+
+Upgrade our HEC-RAS software from 6.0 to 6.3.0.  Even though there is a 6.4x versions, we can not use it at this time.
+
+Note: The actual change was a couple small fixes changing the value of `win32com.client.Dispatch("RAS60.HECRASController")` to `win32com.client.Dispatch("RAS630.HECRASController")`  (60 to 630).  Also changed the default pathing on the file system from 6.0 to 6.3.
+
+The rest of the changes are documentation either in the README.md, output or inline comments.
+
+To apply this update, you must fully un-install HECRAS, then re-install the new version.
+- If you are a NOAA employee, please use software center for this upgrade.
+- If you are not a NOAA employee, please use the link in the README.md file.
+
+
+### Changes  
+
+- `README.md`:  Text updates
+- `src`
+    - `convert_tif_to_ras_hdf5.py`: Comment changes.
+    - `create_shapes_from_hecras.py`: HECRAS controller changed from 60 to 630, plus comment changes.
+    - `ras2fim.py`: Comment and output note changes.
+    - `shared_functions.py`: Comment changes.
+    - `shared_variables.py`: Changed default pathing to the HECRAS software.
+    - `worker_fim_rasters.py`: HECRAS controller changed from 60 to 630, plus comment changes.
+ - `tools`
+     - `nws_ras2fim_terrain_iowa.py`: HECRAS controller changed from 60 to 630, plus comment changes. Note: not tested, not believed to be in use anymore.
+
+<br/><br/>
+
 
 ## v1.27.0 - 2023-09-21 - [PR#165](https://github.com/NOAA-OWP/ras2fim/pull/165)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,12 @@ extend-ignore = """
 
 per-file-ignores = """
     src/create_shapes_from_hecras.py: F841, E731
-    tools/get_ras_models_by_catalog.py: E712, E402    
+    tools/get_models_by_catalog.py: E712, E402
     tools/nws_ras2fim_clip_dem_from_shape.py: E402
     tools/nws_ras2fim_entwine_dem_from_shp.py: E402
     tools/nws_ras2fim_terrain_AWS_tiles.py: E402
     tools/nws_ras2fim_terrain_Texas.py: E402, E501
     tools/nws_ras2fim_terrain_USGS.py: E402
+    tools/ras_unit_to_s3.py: E402
+    tools/s3_shared_functions.py: E402
     """

--- a/src/calculate_all_terrain_stats.py
+++ b/src/calculate_all_terrain_stats.py
@@ -312,7 +312,7 @@ def fn_calculate_all_terrain_stats(str_input_dir):
 
     list_of_list_processed = fn_get_list_of_lists_to_compute(str_input_dir)
 
-    p = mp.Pool(processes=(mp.cpu_count() - 1))
+    p = mp.Pool(processes=(mp.cpu_count() - 2))
 
     len_processed = len(list_of_list_processed)
     list_return_values = list(

--- a/src/conflate_hecras_to_nwm.py
+++ b/src/conflate_hecras_to_nwm.py
@@ -266,7 +266,7 @@ def fn_conflate_hecras_to_nwm(str_huc8_arg, str_shp_in_arg, str_shp_out_arg, str
         list_points_aggregate.append(tpl_request)
 
     # create a pool of processors
-    num_processors = mp.cpu_count() - 1
+    num_processors = mp.cpu_count() - 2
     pool = Pool(processes=num_processors)
 
     len_points_agg = len(list_points_aggregate)
@@ -358,7 +358,7 @@ def fn_conflate_hecras_to_nwm(str_huc8_arg, str_shp_in_arg, str_shp_out_arg, str
     list_dataframe_args_snap = df_points_within_buffer.values.tolist()
 
     print("+-----------------------------------------------------------------+")
-    p = mp.Pool(processes=(mp.cpu_count() - 1))
+    p = mp.Pool(processes=(mp.cpu_count() - 2))
 
     list_df_points_projected = list(
         tqdm.tqdm(

--- a/src/create_fim_rasters.py
+++ b/src/create_fim_rasters.py
@@ -177,7 +177,7 @@ def fn_create_fim_rasters(
         df_streams_merge_2.at[index, "settings"] = tpl_input
 
     # create a pool of processors
-    num_processors = mp.cpu_count() - 1
+    num_processors = mp.cpu_count() - 2
     with Pool(processes=num_processors) as executor:
         df_huc12 = gpd.read_file(str_huc12_area_shp)
         int_huc12_index = 0

--- a/src/create_geocurves.py
+++ b/src/create_geocurves.py
@@ -133,9 +133,9 @@ def manage_geo_rating_curves_production(
         output_folder (str): The path to the output folder where geo rating curves will be written.
     """
     print()
-    overall_start_time = datetime.now()
-    dt_string = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
-    print(f"Started: {dt_string}")
+    overall_start_time = datetime.utcnow()
+    dt_string = datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+    print(f"Started (UTC): {dt_string}")
 
     # Check job numbers and raise error if necessary
     total_cpus_available = os.cpu_count() - 1
@@ -261,9 +261,9 @@ def manage_geo_rating_curves_production(
 
     # Calculate duration
     print()
-    end_time = datetime.now()
-    dt_string = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
-    print(f"Ended: {dt_string}")
+    end_time = datetime.utcnow()
+    dt_string = datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+    print(f"Ended (UTC): {dt_string}")
     time_duration = end_time - overall_start_time
     print(f"Duration: {str(time_duration).split('.')[0]}")
     print()

--- a/src/create_geocurves.py
+++ b/src/create_geocurves.py
@@ -16,8 +16,8 @@ import rasterio
 from rasterio.features import shapes
 from shapely.geometry import MultiPolygon, Polygon
 
+import shared_functions as sf
 import shared_variables as sv
-from shared_functions import get_changelog_version, progress_bar_handler
 
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -171,7 +171,7 @@ def manage_geo_rating_curves_production(
     print(f"Started (UTC): {dt_string}")
 
     # Check job numbers and raise error if necessary
-    total_cpus_available = os.cpu_count() - 1
+    total_cpus_available = os.cpu_count() - 2
     if job_number > total_cpus_available:
         raise ValueError(
             "The job number, {}, "
@@ -216,7 +216,7 @@ def manage_geo_rating_curves_production(
 
     # Check version arg input.
     if os.path.isfile(version):
-        version = get_changelog_version(version)
+        version = sf.get_changelog_version(version)
         print("Version found: " + version)
 
     # Define paths outputs
@@ -282,7 +282,7 @@ def manage_geo_rating_curves_production(
                 sys.exit(1)
 
         # Send the executor to the progress bar and wait for all MS tasks to finish
-        progress_bar_handler(executor_dict, True, f"Creating geocurves with {job_number} workers")
+        sf.progress_bar_handler(executor_dict, True, f"Creating geocurves with {job_number} workers")
 
     # Calculate duration
     print()

--- a/src/create_shapes_from_hecras.py
+++ b/src/create_shapes_from_hecras.py
@@ -674,7 +674,7 @@ def fn_create_shapes_from_hecras(str_ras_path_arg, str_shp_out_arg, str_crs_arg)
         print("Compute HEC-RAS Models: " + str(len(list_models_to_compute)))
 
         # create a pool of processors
-        num_processors = mp.cpu_count() - 1
+        num_processors = mp.cpu_count() - 2
         p = Pool(processes=num_processors)
 
         # multi-process the HEC-RAS calculation of these models

--- a/src/create_shapes_from_hecras.py
+++ b/src/create_shapes_from_hecras.py
@@ -26,6 +26,7 @@ import win32com.client
 from shapely.geometry import LineString
 from shapely.ops import linemerge, split
 
+
 # windows component object model for interaction with HEC-RAS API
 # This routine uses RAS60.HECRASController (HEC-RAS v6.0.0 must be
 # installed on this machine prior to execution)
@@ -458,7 +459,7 @@ def fn_get_flow_dataframe(str_path_hecras_flow_fn):
                 # for each value in the row
                 for k in range(0, int_val_in_row):
                     # get the flow value (Max of 8 characters)
-                    str_flow = line_flows[k * 8: k * 8 + 8].strip()
+                    str_flow = line_flows[k * 8 : k * 8 + 8].strip()
                     # convert the string to a float
                     flt_flow = float(str_flow)
                     # append data to list of flow values
@@ -515,6 +516,11 @@ def fn_cut_stream_downstream(gdf_return_stream_fn, df_xs_fn):
     df_xs_fn["stream_stn"] = df_xs_fn["stream_stn"].astype(float)
 
     # Get minimum stationed cross section
+
+    # TODO: Linting says with these following lines that flt_ds_xs
+    # does not exist and shoudl be removed. But I am not sure that is true
+    # flt_ds_xs = df_xs_fn["stream_stn"].min()
+    # gdf_ds_xs = df_xs_fn.query("stream_stn==@flt_ds_xs")
     flt_ds_xs = df_xs_fn["stream_stn"].min()
     gdf_ds_xs = df_xs_fn.query("stream_stn==@flt_ds_xs")
 
@@ -683,11 +689,9 @@ def fn_create_shapes_from_hecras(str_ras_path_arg, str_shp_out_arg, str_crs_arg)
     list_geodataframes_cross_sections = []
     len_valid_prj_files = len(list_files_valid_prj)
 
-    fn_print_progress_bar(0,
-                          len_valid_prj_files,
-                          prefix="Reading HEC-RAS output",
-                          suffix="Complete",
-                          length=24)
+    fn_print_progress_bar(
+        0, len_valid_prj_files, prefix="Reading HEC-RAS output", suffix="Complete", length=24
+    )
     i = 0
 
     for ras_path in list_files_valid_prj:
@@ -717,11 +721,9 @@ def fn_create_shapes_from_hecras(str_ras_path_arg, str_shp_out_arg, str_crs_arg)
 
         time.sleep(0.03)
         i += 1
-        fn_print_progress_bar(i,
-                              len_valid_prj_files,
-                              prefix="Reading HEC-RAS output",
-                              suffix="Complete",
-                              length=24)
+        fn_print_progress_bar(
+            i, len_valid_prj_files, prefix="Reading HEC-RAS output", suffix="Complete", length=24
+        )
 
     # Create GeoDataframe of the streams and cross sections
     gdf_aggregate_streams = gpd.GeoDataFrame(pd.concat(list_geodataframes_stream, ignore_index=True))

--- a/src/get_usgs_dem_from_shape.py
+++ b/src/get_usgs_dem_from_shape.py
@@ -169,7 +169,7 @@ def fn_get_usgs_dem_from_shape(
 
     # get crs of the input shapefile
     aoi_prj_crs = pyproj.CRS.from_string(str(gdf_aoi_prj.crs))
-    
+
     # convert the input shapefile to lambert
     gdf_aoi_lambert = gdf_aoi_prj.to_crs(LAMBERT)
 
@@ -291,8 +291,10 @@ def fn_get_usgs_dem_from_shape(
         str_URL_header = (
             r"https://elevation.nationalmap.gov/arcgis/services/3DEPElevation/ImageServer/WCSServer?"
         )
-        str_URL_query_1 = r'SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCoverage&coverage=DEP3Elevation' \
-                          r'&CRS=EPSG:3857&FORMAT=GeoTiff'
+        str_URL_query_1 = (
+            r"SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCoverage&coverage=DEP3Elevation"
+            r"&CRS=EPSG:3857&FORMAT=GeoTiff"
+        )
 
         for index, row in gdf_tiles_intersect_only.iterrows():
             list_str_tile_name.append(gdf_tiles_intersect_only["tile_name"][index])
@@ -391,7 +393,7 @@ def fn_get_usgs_dem_from_shape(
             usgs_wcs_local_proj = usgs_wcs_dem.rio.reproject(aoi_prj_crs)
             # rio no longer likes in place reprojections, so we will save to disk temp, then reload
 
-            #usgs_wcs_local_proj = usgs_wcs_dem.rio.write_crs(aoi_prj_crs, inplace=True)
+            # usgs_wcs_local_proj = usgs_wcs_dem.rio.write_crs(aoi_prj_crs, inplace=True)
 
             if model_unit == "feet":
                 # scale the raster from meters to feet

--- a/src/ras2catchments.py
+++ b/src/ras2catchments.py
@@ -500,8 +500,6 @@ def make_catchments(
 
     print("Getting maxment files")
 
-    num_processors = mp.cpu_count() - 1
-
     # Create a list of lists with the mxmt args for the multi-proc
     mxmts_args = []
     for feature_id in all_feature_ids:
@@ -509,6 +507,7 @@ def make_catchments(
 
     rasters_paths_to_mosaic = []
 
+    num_processors = mp.cpu_count() - 2
     with Pool(processes=num_processors) as executor:
         rasters_paths_to_mosaic = list(
             tqdm.tqdm(

--- a/src/ras2catchments.py
+++ b/src/ras2catchments.py
@@ -132,7 +132,7 @@ def vectorize(mosaic_features_raster_path, changelog_path, model_huc_catalog_pat
     gdf.rename(columns={"last_modified": "hecras_model_last_modified"}, inplace=True)
 
     # populate the rating_curve field with today's utc date
-    gdf["last_updated"] = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    gdf["last_updated"] = dt.datetime.utcnow(dt.timezone.utc).strftime("%Y-%m-%d")
     # renamed a few columns
     gdf.rename(columns={"last_updated": "ras2fim_processed_date"}, inplace=True)
 
@@ -381,7 +381,7 @@ def make_catchments(
 
     ####################################################################
     #  Start processing
-    start_dt = dt.datetime.now()
+    start_dt = dt.datetime.utcnow()
 
     print(" ")
     print("+=================================================================+")
@@ -582,7 +582,7 @@ def make_catchments(
     # -------------------
     print()
     print("ras2catchment processing complete")
-    sf.print_date_time_duration(start_dt, dt.datetime.now())
+    sf.print_date_time_duration(start_dt, dt.datetime.utcnow())
     print("===================================================================")
     print("")
 

--- a/src/ras2fim.py
+++ b/src/ras2fim.py
@@ -88,12 +88,11 @@ def init_and_run_ras2fim(
     if str_huc8_arg.isnumeric() is False:  # can handle leading zeros
         raise ValueError("the -w flag (HUC8) does not appear to be a HUC8")
 
-
     # -------------------
     # -i  (ie OWP_ras_models\models) (HECRAS models)
     if os.path.exists(input_models_path) is False:
         raise ValueError(f"the -i arg ({input_models_path}) does not appear to be a valid folder.")
-    
+
     # -------------------
     proj_crs = pyproj.CRS.from_string(str_crs_arg)
     model_unit = sf.confirm_models_unit(proj_crs, input_models_path)

--- a/src/ras2fim.py
+++ b/src/ras2fim.py
@@ -377,7 +377,7 @@ def fn_run_ras2fim(
     flt_resolution_depth_grid = int(output_resolution)
 
     print()
-    print("+++++++ Processing:  STEP 5/6 (simplifying fim rasters and create metrics)  +++++++")
+    print("+++++++ Processing:  STEP 5.b (simplifying fim rasters and create metrics)  +++++++")
 
     fn_simplify_fim_rasters(
         str_hecras_out_dir, flt_resolution_depth_grid, sv.DEFAULT_RASTER_OUTPUT_CRS, model_unit

--- a/src/reformat_ras_rating_curve.py
+++ b/src/reformat_ras_rating_curve.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import datetime
+import datetime as dt
 import os
 import shutil
 import sys
@@ -382,7 +382,7 @@ def dir_reformat_ras_rc(
         # Build output table
 
         # Get a current timestamp
-        timestamp = datetime.datetime.now()
+        timestamp = dt.datetime.utcnow()
 
         # Assemble output table
         dir_output_table = pd.DataFrame(
@@ -466,7 +466,7 @@ def dir_reformat_ras_rc(
             print(f"Saved directory outputs for {dir_input_folder_path}.")
 
         # Get timestamp for metadata
-        start_time_string = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")
+        start_time_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
 
         # Write README metadata file for the intermediate file
         write_metadata_file(
@@ -530,8 +530,8 @@ def compile_ras_rating_curves(
     intermediate_filename = sv.R2F_OUTPUT_DIR_RAS2CALIBRATION
 
     # Record and print start time
-    start_time = datetime.datetime.now()
-    start_time_string = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")
+    start_time = dt.datetime.utcnow()
+    start_time_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
 
     # Settings block
     print("-----------------------------------------------------------------------------------------------")
@@ -801,7 +801,7 @@ def compile_ras_rating_curves(
     )
 
     # Record end time, calculate runtime, and print runtime
-    end_time = datetime.datetime.now()
+    end_time = dt.datetime.utcnow()
     runtime = end_time - start_time
 
     print()

--- a/src/run_ras2rem.py
+++ b/src/run_ras2rem.py
@@ -144,7 +144,7 @@ def fn_make_rems(r2f_simplified_grids_dir, r2f_ras2rem_dir):
     num_processors = mp.cpu_count() - 1
     with Pool(processes=num_processors) as executor:
         # pool = Pool(processes = num_processors)
-        list_of_returned_results = list(
+        list(
             tqdm.tqdm(
                 executor.imap(fn_generate_tif_for_each_rem, rem_info_arguments),
                 total=len(rem_values),

--- a/src/run_ras2rem.py
+++ b/src/run_ras2rem.py
@@ -141,7 +141,7 @@ def fn_make_rems(r2f_simplified_grids_dir, r2f_ras2rem_dir):
     for rem_value in rem_values:
         rem_info_arguments.append((rem_value, r2f_simplified_grids_dir, r2f_ras2rem_dir))
 
-    num_processors = mp.cpu_count() - 1
+    num_processors = mp.cpu_count() - 2
     with Pool(processes=num_processors) as executor:
         # pool = Pool(processes = num_processors)
         list(

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -26,7 +26,7 @@ from errors import ModelUnitError
 
 
 # -------------------------------------------------
-def confirm_models_unit(proj_crs, str_ras_path_arg):
+def confirm_models_unit(proj_crs, input_models_path):
     """
     - calls two other functions to infer units from ras models and -p projection.
     - raises an exception if units do not match.
@@ -35,7 +35,11 @@ def confirm_models_unit(proj_crs, str_ras_path_arg):
 
     unit = None
     try:
-        unit_from_ras = model_unit_from_ras_prj(str_ras_path_arg)
+
+        if os.path.exists(input_models_path) is False: 
+            raise ValueError(f"The path of {input_models_path} can not be found.")
+
+        unit_from_ras = model_unit_from_ras_prj(input_models_path)
         unit_from_crs = model_unit_from_crs(proj_crs)
 
         if unit_from_ras == unit_from_crs:  # if both are the same, return one of them

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import datetime as dt
 import fnmatch
 import json
 import os
@@ -8,7 +9,6 @@ import random
 import re
 import string
 import sys
-from datetime import datetime as dt
 from pathlib import Path
 
 import keepachangelog
@@ -17,44 +17,9 @@ import pandas as pd
 import rasterio
 from dotenv import load_dotenv
 
-import shared_validators as svd
+import shared_validators as val
 import shared_variables as sv
 from errors import ModelUnitError
-
-
-# -------------------------------------------------
-def print_date_time_duration(start_dt, end_dt):
-    """
-    Process:
-    -------
-    Calcuates the diffenence in time between the start and end time
-    and prints is as:
-
-        Duration: 4 hours 23 mins 15 secs
-
-    -------
-    Usage:
-        from utils.shared_functions import FIM_Helpers as fh
-        fh.print_current_date_time()
-
-    -------
-    Returns:
-        Duration as a formatted string
-
-    """
-    time_delta = end_dt - start_dt
-    total_seconds = int(time_delta.total_seconds())
-
-    total_days, rem_seconds = divmod(total_seconds, 60 * 60 * 24)
-    total_hours, rem_seconds = divmod(rem_seconds, 60 * 60)
-    total_mins, seconds = divmod(rem_seconds, 60)
-
-    time_fmt = f"{total_hours:02d} hours {total_mins:02d} mins {seconds:02d} secs"
-
-    duration_msg = "Duration: " + time_fmt
-    print(duration_msg)
-
-    return duration_msg
 
 
 # -------------------------------------------------
@@ -241,7 +206,8 @@ def fix_proj_path_error():
 
     # https://github.com/rasterio/rasterio/blob/master/docs/faq.rst#why-cant-rasterio-find-projdb-rasterio-from-pypi-versions--120
 
-    # Says for now. You have to point to older versions of proj and gdal but I tried a number of combinations and no luck yet
+    # Says for now. You have to point to older versions of proj and gdal but I tried a number of
+    # combinations and no luck yet
 
     # If the PROJ_DB path (from pyrpo is incorrect, you will see bounding box issues such as
     # rioxarray.exceptions.NoDataInBounds: No data found in bounds.
@@ -261,9 +227,10 @@ def fix_proj_path_error():
     # PROJ_LIB="C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\GDAL\\common\\data'
     # GDAL_DATA="C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.0\\GDAL\\common\\data'
 
-    # File 'C:\Users\rdp-user\Projects\dev-linter\ras2fim\src\get_usgs_dem_from_shape.py', line 428, in fn_get_usgs_dem_from_shape
-    #    usgs_wcs_local_proj_clipped = usgs_wcs_local_proj.rio.clip(str_geom)
-    # File 'C:\Users\rdp-user\anaconda3\envs\ras2fim\lib\site-packages\rioxarray\raster_array.py', line 943, in clip
+    # File 'C:\Users\rdp-user\Projects\dev-linter\ras2fim\src\get_usgs_dem_from_shape.py', line 428,
+    #    in fn_get_usgs_dem_from_shape usgs_wcs_local_proj_clipped = usgs_wcs_local_proj.rio.clip(str_geom)
+    # File 'C:\Users\rdp-user\anaconda3\envs\ras2fim\lib\site-packages\rioxarray\raster_array.py',
+    #   line 943, in clip
     #    raise NoDataInBounds(
     # rioxarray.exceptions.NoDataInBounds: No data found in bounds.
 
@@ -309,7 +276,7 @@ def fix_proj_path_error():
     except Exception as ex:
         print()
         print(
-            "***An internal error has occurred while attempting to load the proj and gdal"
+            "*** An internal error has occurred while attempting to load the proj and gdal"
             " environment variables. Details"
         )
         print(ex)
@@ -384,8 +351,52 @@ def fn_get_random_string(int_letter_len_fn, int_num_len_fn):
 
 # -------------------------------------------------
 def get_stnd_date():
-    # return YYMMDD as in 230725
-    return dt.now().strftime("%y%m%d")
+    # Standardizes date pattern
+    # Returns YYMMDD as in 230725  (UTC)
+
+    str_date = dt.utcnow.strftime("%y%m%d")
+    return str_date
+
+
+# -------------------------------------------------
+def print_date_time_duration(start_dt, end_dt):
+    # *********************
+    # NOTE:  Ensure the date/tims coming in are UTC in all situations including
+    #     just duration's, even though it really doesn't matter for durations.
+    #     We are attempting to use UTC for ALL dates
+    # *********************
+
+    """
+    Process:
+    -------
+    Calcuates the diffenence in time between the start and end time
+    and prints is as:
+
+        Duration: 4 hours 23 mins 15 secs
+
+    -------
+    Usage:
+        from utils.shared_functions as sf
+        fh.print_current_date_time()
+
+    -------
+    Returns:
+        Duration as a formatted string
+
+    """
+    time_delta = end_dt - start_dt
+    total_seconds = int(time_delta.total_seconds())
+
+    total_days, rem_seconds = divmod(total_seconds, 60 * 60 * 24)
+    total_hours, rem_seconds = divmod(rem_seconds, 60 * 60)
+    total_mins, seconds = divmod(rem_seconds, 60)
+
+    time_fmt = f"{total_hours:02d} hours {total_mins:02d} mins {seconds:02d} secs"
+
+    duration_msg = "Duration: " + time_fmt
+    print(duration_msg)
+
+    return duration_msg
 
 
 # -------------------------------------------------
@@ -408,7 +419,7 @@ def get_stnd_r2f_output_folder_name(huc_number, crs):
 
     # -------------------
     # validate and split out the crs number.
-    is_valid_crs, err_msg, crs_number = svd.is_valid_crs(crs)
+    is_valid_crs, err_msg, crs_number = val.is_valid_crs(crs)
 
     if is_valid_crs is False:
         raise ValueError(err_msg)

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import datetime as dt
 import fnmatch
 import json
 import os
@@ -35,8 +34,7 @@ def confirm_models_unit(proj_crs, input_models_path):
 
     unit = None
     try:
-
-        if os.path.exists(input_models_path) is False: 
+        if os.path.exists(input_models_path) is False:
             raise ValueError(f"The path of {input_models_path} can not be found.")
 
         unit_from_ras = model_unit_from_ras_prj(input_models_path)

--- a/src/shared_functions.py
+++ b/src/shared_functions.py
@@ -358,7 +358,7 @@ def get_stnd_date():
     # Standardizes date pattern
     # Returns YYMMDD as in 230725  (UTC)
 
-    str_date = dt.utcnow.strftime("%y%m%d")
+    str_date = dt.utcnow().strftime("%y%m%d")
     return str_date
 
 

--- a/src/shared_validators.py
+++ b/src/shared_validators.py
@@ -2,7 +2,7 @@
 
 ####################################################################
 """
-This file is for validation that can be used in more than one py file.
+This script is for validation of inputs and object that can be used in py files.
 """
 
 

--- a/src/shared_variables.py
+++ b/src/shared_variables.py
@@ -1,5 +1,6 @@
 import os
 
+
 """
 This is a collection of variables that help manage, centralize and standarize some values,
    such as pathing, or common valuse
@@ -18,23 +19,15 @@ INPUT_NWM_WBD_LOOKUP_FILE = "nwm_wbd_lookup.nc"
 INPUT_WBD_NATIONAL_FILE = "WBD_National.gpkg"
 INPUT_NWM_CATCHMENTS_FILE = "nwm_catchments.gpkg"
 INPUT_WBD_HUC8_DIR = "WBD_HUC8"  # Pattern for huc files are 'HUC8_{huc number}.gpkg'
-INPUT_DEFAULT_NWM_FLOWS_FILE_PATH = os.path.join(
-    INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_FLOWS_FILE
-)
-INPUT_DEFAULT_NWM_WBD_LOOKUP_FILE_PATH = os.path.join(
-    INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_FLOWS_FILE
-)
+INPUT_DEFAULT_NWM_FLOWS_FILE_PATH = os.path.join(INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_FLOWS_FILE)
+INPUT_DEFAULT_NWM_WBD_LOOKUP_FILE_PATH = os.path.join(INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_FLOWS_FILE)
 INPUT_DEFAULT_INPUT_WBD_NATIONAL_FILE_PATH = os.path.join(
     INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_WBD_NATIONAL_FILE
 )
-INPUT_DEFAULT_NWM_FLOWS_FILE_PATH = os.path.join(
-    INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_CATCHMENTS_FILE
-)
+INPUT_DEFAULT_NWM_FLOWS_FILE_PATH = os.path.join(INPUT_DEFAULT_X_NATIONAL_DS_DIR, INPUT_NWM_CATCHMENTS_FILE)
 
 # OWP RAS MODELS (pre-processed, ready to submit to ras2fim.py)
-DEFAULT_OWP_RAS_MODELS_MODEL_PATH = os.path.join(
-    DEFAULT_BASE_DIR, "OWP_ras_models", "models"
-)
+DEFAULT_OWP_RAS_MODELS_MODEL_PATH = os.path.join(DEFAULT_BASE_DIR, "OWP_ras_models", "models")
 DEFAULT_RSF_MODELS_CATALOG_FILE = os.path.join(
     DEFAULT_BASE_DIR, "OWP_ras_models", "OWP_ras_models_catalog_[].csv"
 )
@@ -63,6 +56,10 @@ R2F_OUTPUT_FILE_RAS2CAL_CSV = "ras2calibration_output_table.csv"
 R2F_OUTPUT_FILE_RAS2CAL_GPKG = "ras2calibration_output_geopackage.gpkg"
 R2F_OUTPUT_FILE_RAS2CAL_LOG = "ras2calibration_log.txt"
 
+# S3 PATHS (FOLDERS)
+S3_OUTPUT_RAS2FIM_FOLDER = "output_ras2fim"
+S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER = "output_ras2fim_archive"
+S3_OUTPUT_TRACKER_FILE = "ras_output_tracker.csv"
 
 # NODATA VALUE
 DEFAULT_NODATA_VAL = 0 - 9999

--- a/src/simplify_fim_rasters.py
+++ b/src/simplify_fim_rasters.py
@@ -84,7 +84,7 @@ def fn_create_grid(list_of_df_row):
         model_unit,
     ) = list_of_df_row
 
-    #print(f"flt_desired_res is {flt_desired_res}")
+    # print(f"flt_desired_res is {flt_desired_res}")
 
     # read in the HEC-RAS generatated polygon of the last elevation step
     gdf_flood_limits = gpd.read_file(str_polygon_path)
@@ -122,9 +122,9 @@ def fn_create_grid(list_of_df_row):
 
         # TODO: Sept 9, 2023
         # The plan was to resample the scalled to the desired resolution (ie. 10)
-        # But an upgrade in rioxarray means merge is no longer available (ish). 
+        # But an upgrade in rioxarray means merge is no longer available (ish).
         # It may have been used incorrectly as merge_arrays implies two datasets
-        # but there was only one. 
+        # but there was only one.
 
         # For now.. just skip attempting to upscale or downscale the resolution
         # Note: If upscaling or downscaling, image sizes need to be adjusted.
@@ -141,7 +141,6 @@ def fn_create_grid(list_of_df_row):
         """
 
         xds_clipped_reproject_scaled.rio.to_raster(str_file_to_create_path, compress="lzw", dtype="uint16")
-
 
         sleep(0.01)  # this allows the tqdm progress bar to update
 
@@ -307,12 +306,13 @@ def fn_simplify_fim_rasters(r2f_hecras_outputs_dir, flt_resolution, str_output_c
         print("+-----------------------------------------------------------------+")
         p = mp.Pool(processes=(mp.cpu_count() - 1))
 
-        list(tqdm.tqdm(
+        list(
+            tqdm.tqdm(
                 p.imap(fn_create_grid, list_dataframe_args),
                 total=len_grids_convert,
                 desc="Convert Grids",
                 bar_format="{desc}:({n_fmt}/{total_fmt})|{bar}| {percentage:.1f}%",
-                ncols=65
+                ncols=65,
             )
         )
 
@@ -352,8 +352,7 @@ def fn_simplify_fim_rasters(r2f_hecras_outputs_dir, flt_resolution, str_output_c
         # also combine all files into a single file
         all_rating_curve_df = pd.concat([all_rating_curve_df, this_file_df])
 
-    r2f_metric_dir = r2f_hecras_outputs_dir.replace(sv.R2F_OUTPUT_DIR_HECRAS_OUTPUT,
-                                                    sv.R2F_OUTPUT_DIR_METRIC)
+    r2f_metric_dir = r2f_hecras_outputs_dir.replace(sv.R2F_OUTPUT_DIR_HECRAS_OUTPUT, sv.R2F_OUTPUT_DIR_METRIC)
     all_rating_curve_df.to_csv(os.path.join(r2f_metric_dir, "all_rating_curves.csv"), index=False)
 
     print("Making metric wse for cross sections")
@@ -386,8 +385,7 @@ def fn_simplify_fim_rasters(r2f_hecras_outputs_dir, flt_resolution, str_output_c
         # also combine all files into a single file
         all_xs_df = pd.concat([all_xs_df, this_file_df])
 
-    r2f_metric_dir = r2f_hecras_outputs_dir.replace(sv.R2F_OUTPUT_DIR_HECRAS_OUTPUT,
-                                                    sv.R2F_OUTPUT_DIR_METRIC)
+    r2f_metric_dir = r2f_hecras_outputs_dir.replace(sv.R2F_OUTPUT_DIR_HECRAS_OUTPUT, sv.R2F_OUTPUT_DIR_METRIC)
     all_xs_df.to_csv(os.path.join(r2f_metric_dir, "all_cross_sections.csv"), index=False)
 
     print("COMPLETE")

--- a/src/simplify_fim_rasters.py
+++ b/src/simplify_fim_rasters.py
@@ -304,7 +304,7 @@ def fn_simplify_fim_rasters(r2f_hecras_outputs_dir, flt_resolution, str_output_c
         list_dataframe_args = df_grids_to_convert.values.tolist()
 
         print("+-----------------------------------------------------------------+")
-        p = mp.Pool(processes=(mp.cpu_count() - 1))
+        p = mp.Pool(processes=(mp.cpu_count() - 2))
 
         list(
             tqdm.tqdm(

--- a/src/worker_fim_rasters.py
+++ b/src/worker_fim_rasters.py
@@ -14,25 +14,17 @@
 # ************************************************************
 
 import os
-import json
 import re
-
 import traceback
 from datetime import date
 
-import geopandas as gpd
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tick
 import numpy as np
 import pandas as pd
 import win32com.client
 
-# from rasterio.warp import calculate_default_transform, reproject
-from rasterio import Affine
-from rasterio.enums import Resampling
-from rasterio.mask import mask
 from scipy.interpolate import interp1d
-from shapely.geometry import LineString
 
 import shared_functions as sf
 
@@ -284,7 +276,7 @@ def fn_create_rating_curve(
         df_rating_curve["stage_mm"] = df_rating_curve["stage_mm"].astype("int")
 
         df_rating_curve["wse_m"] = np.round(df_rating_curve["wse_ft"].values * 0.3048, 3)
-    else:  ## meters
+    else:  # meters
         # need rounding (precison control even for unit of meters)
         df_rating_curve["discharge_cms"] = np.round(df_rating_curve["discharge_cms"].values, 3)
         df_rating_curve["stage_m"] = np.round(df_rating_curve["stage_m"].values, 3)
@@ -332,7 +324,6 @@ def fn_create_flow_file_second_pass(
         str_flow_title = str_flow_title[11:]  # remove first 11 characters
 
     int_fn_num_profiles = len(list_step_profiles_fn)
-
 
     f1.close()
 
@@ -458,12 +449,7 @@ def fn_create_ras_mapper_xml(
 
         if model_unit == "meter":
             str_ras_mapper_file += (
-                'Terrain" StoredFilename=".'
-                 + "\\BLE_"
-                 + str_feature_id_fn
-                 + "\\Depth (" 
-                 + str(i) 
-                 + 'm).vrt"'
+                'Terrain" StoredFilename=".' + "\\BLE_" + str_feature_id_fn + "\\Depth (" + str(i) + 'm).vrt"'
             )
         else:
             str_ras_mapper_file += (
@@ -547,9 +533,9 @@ def fn_create_ras_mapper_xml(
 '''
 # """"""""""""""""""""""""""
 def fn_create_study_area(str_polygon_path_fn, str_feature_id_poly_fn, tpl_settings):
-    
+
     # get settings from the tpl_settings
-    flt_buffer = tpl_settings[14] 
+    flt_buffer = tpl_settings[14]
 
     # Function to create the study limits shapefile (polyline)
 
@@ -626,7 +612,7 @@ def fn_run_hecras(str_ras_projectpath, int_peak_flow, model_unit, tpl_settings):
         # reading project nodes: cross-sections, bridges, culverts, etc.
         v1, v2, NNod, TabRS, TabNTyp = hec.Geometry_GetNodes(RivID, RchID, NNod, TabRS, TabNTyp)
 
-        # HEC-RAS ID of output variables: Max channel depth, channel reach length, 
+        # HEC-RAS ID of output variables: Max channel depth, channel reach length,
         # and water surface elevation
         int_max_depth_id, int_node_chan_length, int_water_surface_elev, int_q_total = 4, 42, 2, 9
 

--- a/src/worker_fim_rasters.py
+++ b/src/worker_fim_rasters.py
@@ -24,9 +24,6 @@ import pandas as pd
 import win32com.client
 
 # from rasterio.warp import calculate_default_transform, reproject
-from rasterio import Affine
-from rasterio.enums import Resampling
-from rasterio.mask import mask
 from scipy.interpolate import interp1d
 
 import shared_functions as sf

--- a/tools/get_models_by_catalog.py
+++ b/tools/get_models_by_catalog.py
@@ -12,9 +12,10 @@ import traceback
 import pandas as pd
 import s3fs
 
-sys.path.append("..")
-import ras2fim.src.shared_validators as val
-import ras2fim.src.shared_variables as sv
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+import shared_validators as val
+import shared_variables as sv
 
 
 """
@@ -138,6 +139,7 @@ class Get_Models_By_Catalog:
         dt_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
         self.lprint("****************************************")
         self.lprint(f"Get ras models folders from s3 started: {dt_string}")
+        self.lprint(f" ... HUC: {huc_number} ; CRS: {projection} ...")
 
         # ----------
         # Validate inputs
@@ -149,6 +151,12 @@ class Get_Models_By_Catalog:
             target_owp_ras_models_csv_file,
             list_only,
         )
+
+        self.lprint(f"Source download path for models is {self.src_owp_model_folder_path}")
+        self.lprint(f"Target file name and path for the filtered csv is {self.target_filtered_csv_path}")
+        self.lprint(f"Target path for models is {self.target_owp_ras_models_path}")
+        self.lprint("")
+
 
         self.list_only = list_only
         self.is_verbose = is_verbose
@@ -311,7 +319,7 @@ class Get_Models_By_Catalog:
         self.huc_number = huc_number
 
         # ---------------
-        crs_number, is_valid, err_msg = val.is_valid_crs(projection)  # I don't need the crs_number for now
+        is_valid, err_msg, crs_number = val.is_valid_crs(projection)  # I don't need the crs_number for now
         if is_valid is False:
             raise ValueError(err_msg)
 
@@ -368,10 +376,6 @@ class Get_Models_By_Catalog:
         target_owp_ras_models_path_parent = os.path.dirname(target_owp_ras_models_path)
         self.log_folder_path = os.path.join(target_owp_ras_models_path_parent, "logs")
 
-        self.lprint(f"Source download path for models is {self.src_owp_model_folder_path}")
-        self.lprint(f"Target file name and path for the filtered csv is {self.target_filtered_csv_path}")
-        self.lprint(f"Target path for models is {self.target_owp_ras_models_path}")
-        self.lprint("")
 
     # -------------------------------------------------
     def download_files(self, folder_list):

--- a/tools/get_models_by_catalog.py
+++ b/tools/get_models_by_catalog.py
@@ -157,7 +157,6 @@ class Get_Models_By_Catalog:
         self.lprint(f"Target path for models is {self.target_owp_ras_models_path}")
         self.lprint("")
 
-
         self.list_only = list_only
         self.is_verbose = is_verbose
         # from here on, use the self. in front of variables as the variable might have been adjusted
@@ -182,18 +181,22 @@ class Get_Models_By_Catalog:
 
             filter_msg = (
                 "Note: some may have been filtered out. Current filters are: status is ready;"
-                " final_name_key does not start with 1_ or 2_; huc number exists in the huc column;"
-                " and matching crs column values."
+                " final_name_key does not start with 1_, 2_ or 3_; huc number exists in the huc column;"
+                " and matching crs column values.\n"
+                " 1_ and 2_ means errors or needs review in pre-processing.\n"
+                " 3_ means invalid conflation and needs review in preprocessing."
             )
 
-            # look for records that are ready, contains the huc number and does not start with 1_ or 20_
-            # NOTE: for some reason if you change
-            # df_all["final_name_key"].str.startswith("1_") == False)  to
-            # df_all["final_name_key"].str.startswith("1_") is False).. it fails. and Not doesnt' work either
+            # look for records that are ready, contains the huc number and does not start with 1_, 2_ or 3_
+            # NOTE: for some reason if you change the lines below, now that the pattern of:
+            # df_all["final_name_key"].str.startswith("1_") is False).. it fails (not sure why)
+            # So I keep the pattern of == False.
+            # #### The E712 override has been added to the toml file.
             df_huc = df_all.loc[
                 (df_all["status"] == "ready")
                 & (df_all["final_name_key"].str.startswith("1_") == False)
                 & (df_all["final_name_key"].str.startswith("2_") == False)
+                & (df_all["final_name_key"].str.startswith("3_") == False)
                 & (df_all["hucs"].str.contains(str(self.huc_number), na=False))
             ]
 
@@ -375,7 +378,6 @@ class Get_Models_By_Catalog:
         # models target.
         target_owp_ras_models_path_parent = os.path.dirname(target_owp_ras_models_path)
         self.log_folder_path = os.path.join(target_owp_ras_models_path_parent, "logs")
-
 
     # -------------------------------------------------
     def download_files(self, folder_list):

--- a/tools/get_models_by_catalog.py
+++ b/tools/get_models_by_catalog.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
 import argparse
+import datetime as dt
 import os
 import shutil
 import subprocess
 import sys
 import time
 import traceback
-from datetime import datetime
 
 import pandas as pd
 import s3fs
 
-
 sys.path.append("..")
+import ras2fim.src.shared_validators as val
 import ras2fim.src.shared_variables as sv
 
 
@@ -64,7 +64,7 @@ MODELS_CATALOG_COLUMN_DOWNLOAD_FAIL_REASON = "download_fail_reason"
 
 
 # -------------------------------------------------
-class Get_Ras_Models_By_Catalog:
+class Get_Models_By_Catalog:
     # -------------------------------------------------
     # default values listed in "__main__"  but also here in case code calls direct..
     # aka. not through "__main__"
@@ -133,11 +133,11 @@ class Get_Ras_Models_By_Catalog:
 
         """
 
-        self.log_append_and_print("")
-        start_time = datetime.now()
-        dt_string = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
-        self.log_append_and_print("****************************************")
-        self.log_append_and_print(f"Get ras models folders from s3 started: {dt_string}")
+        self.lprint("")
+        start_time = dt.datetime.utcnow()
+        dt_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+        self.lprint("****************************************")
+        self.lprint(f"Get ras models folders from s3 started: {dt_string}")
 
         # ----------
         # Validate inputs
@@ -162,13 +162,13 @@ class Get_Ras_Models_By_Catalog:
             df_all = pd.read_csv(self.s3_path_to_catalog_file, header=0, encoding="unicode_escape")
 
             if df_all.empty:
-                self.log_append_and_print("The model catalog appears to be empty or did not load correctly")
+                self.lprint("The model catalog appears to be empty or did not load correctly")
                 return
 
             df_all["nhdplus_comid"] = df_all["nhdplus_comid"].astype(str)
 
             if self.is_verbose is True:
-                self.log_append_and_print(f"models catalog raw record count = {len(df_all)}")
+                self.lprint(f"models catalog raw record count = {len(df_all)}")
 
             # ----------
 
@@ -179,7 +179,7 @@ class Get_Ras_Models_By_Catalog:
             )
 
             # look for records that are ready, contains the huc number and does not start with 1_ or 20_
-            # NOTE: for some reason if you change 
+            # NOTE: for some reason if you change
             # df_all["final_name_key"].str.startswith("1_") == False)  to
             # df_all["final_name_key"].str.startswith("1_") is False).. it fails. and Not doesnt' work either
             df_huc = df_all.loc[
@@ -190,23 +190,21 @@ class Get_Ras_Models_By_Catalog:
             ]
 
             if df_huc.empty:
-                self.log_append_and_print(f"No valid records return for {self.huc_number}. {filter_msg}")
+                self.lprint(f"No valid records return for {self.huc_number}. {filter_msg}")
                 return
 
             # ----------
             # Now filter based on CRS
             self.df_filtered = df_huc.loc[(df_huc["crs"] == self.projection)]
             if self.df_filtered.empty:
-                self.log_append_and_print(
+                self.lprint(
                     f"No valid records return for {huc_number} and crs {self.projection}. {filter_msg}"
                 )
                 return
 
             self.df_filtered.reset_index(inplace=True)
 
-            self.log_append_and_print(
-                f"Number of model records after filtering is {len(self.df_filtered)} (pre-download)."
-            )
+            self.lprint(f"Number of model records after filtering is {len(self.df_filtered)} (pre-download).")
 
             if self.is_verbose is True:
                 # to see the huc list without column trucations (careful as this could be a huge output)
@@ -224,9 +222,9 @@ class Get_Ras_Models_By_Catalog:
 
             # we will save it initially but update it and save it again as it goes
             self.df_filtered.to_csv(self.target_filtered_csv_path, index=False)
-            self.log_append_and_print(f"Filtered model catalog saved to : {self.target_filtered_csv_path}")
+            self.lprint(f"Filtered model catalog saved to : {self.target_filtered_csv_path}")
             if self.list_only is False:
-                self.log_append_and_print(
+                self.lprint(
                     "Note: This csv represents all filtered models folders that are pending to be"
                     " downloaded.\nThe csv will be updated with statuses after downloads are complete."
                 )
@@ -240,33 +238,21 @@ class Get_Ras_Models_By_Catalog:
             # If inc_download_folders, otherwise we just stop.  Sometimes a list is wanted but
             # not the downloads
             if self.list_only is False:
-                # loop through df_huc records and using name, pull down
-                # TODO: Add a progress bar and multi proc, BUT....
-                # S3 does not like two many simulations downloads at a time. It has to do with
-                # the network speed of your machine.
-                # Just keep an eye on it when multi threading.
-                # For now, it is pretty fast anyways.
                 self.download_files(folders_to_download)
 
-            self.log_append_and_print("")
+            self.lprint("")
             if self.list_only is True:
-                self.log_append_and_print("List only as per (-f) flag - no downloads attempted")
-                self.log_append_and_print(
+                self.lprint("List only as per (-f) flag - no downloads attempted")
+                self.lprint(
                     "Number of model folders which would be attempted to downloaded is"
                     f" {len(self.df_filtered)}"
                 )
             else:
-                self.log_append_and_print(
-                    f"Number of models folders successfully downloaded: {self.num_success_downloads}"
-                )
+                self.lprint(f"Number of models folders successfully downloaded: {self.num_success_downloads}")
                 num_skips = self.num_pending_downloads - self.num_success_downloads
-                self.log_append_and_print(
-                    f"Number of models folders skipped / errored during download: {num_skips}"
-                )
+                self.lprint(f"Number of models folders skipped / errored during download: {num_skips}")
                 if num_skips > 0:
-                    self.log_append_and_print(
-                        "Please review the output logs or the filtered csv for skip/error details."
-                    )
+                    self.lprint("Please review the output logs or the filtered csv for skip/error details.")
 
         except ValueError:
             errMsg = "--------------------------------------\n An error has occurred"
@@ -278,20 +264,20 @@ class Get_Ras_Models_By_Catalog:
         except Exception:
             errMsg = "--------------------------------------\n An error has occurred"
             errMsg = errMsg + traceback.format_exc()
-            self.log_append_and_print(errMsg)
+            self.lprint(errMsg)
 
         # resaved with the updates to the download columns
         if (self.df_filtered.empty is False) and (self.list_only is False):
             self.df_filtered.to_csv(self.target_filtered_csv_path, index=False)
-            self.log_append_and_print("Filtered model catalog has been update.")
+            self.lprint("Filtered model catalog has been update.")
 
-        end_time = datetime.now()
-        dt_string = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
-        self.log_append_and_print(f"ended: {dt_string}")
+        end_time = dt.datetime.utcnow()
+        dt_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+        self.lprint(f"ended: {dt_string}")
 
         # Calculate duration
         time_duration = end_time - start_time
-        self.log_append_and_print(f"Duration: {str(time_duration).split('.')[0]}")
+        self.lprint(f"Duration: {str(time_duration).split('.')[0]}")
 
         self.save_logs()
         print()
@@ -325,24 +311,9 @@ class Get_Ras_Models_By_Catalog:
         self.huc_number = huc_number
 
         # ---------------
-        if (projection is None) or (
-            projection == ""
-        ):  # Possible if not coming via the __main__ (also possible)
-            raise ValueError("projection (-p) value not set")
-
-        projection = projection.upper()
-
-        # CRS pattern must be in '4 alpha chars' + ':' + 4 or 5 digits.  ie) EPSG:2277 or ESRI:102739
-        # reg of re.match(r'^[a-zA-Z]{4}:[1-9]{4,6}$', projection) == False): split against the color
-        projection_seg = projection.split(":")
-        if len(projection_seg) != 2:
-            raise ValueError(
-                "crs value appears to be incorrect (four letters, then a colon, then 4 or 5 numbers)."
-                " e.g. ESRI:102739"
-            )
-
-        if projection_seg[0] != "ESRI" and projection_seg[0] != "EPSG":
-            raise ValueError("crs value appears to be incorrect. Expected to start with EPSG or ESRI")
+        crs_number, is_valid, err_msg = val.is_valid_crs(projection)  # I don't need the crs_number for now
+        if is_valid is False:
+            raise ValueError(err_msg)
 
         self.projection = projection
 
@@ -351,6 +322,7 @@ class Get_Ras_Models_By_Catalog:
             raise ValueError("target_owp_ras_models_csv_file can not be empty")
 
         # ---------------
+        target_owp_ras_models_path = target_owp_ras_models_path.replace("/", "\\")
         self.target_owp_ras_models_path = target_owp_ras_models_path
 
         if list_only is False:
@@ -358,7 +330,7 @@ class Get_Ras_Models_By_Catalog:
                 shutil.rmtree(self.target_owp_ras_models_path)
                 # shutil.rmtree is not instant, it sends a command to windows, so do a quick time out here
                 # so sometimes mkdir can fail if rmtree isn't done
-                time.sleep(2)  # 2 seconds
+                time.sleep(1)  # 2 seconds
 
             os.mkdir(self.target_owp_ras_models_path)
 
@@ -396,17 +368,15 @@ class Get_Ras_Models_By_Catalog:
         target_owp_ras_models_path_parent = os.path.dirname(target_owp_ras_models_path)
         self.log_folder_path = os.path.join(target_owp_ras_models_path_parent, "logs")
 
-        self.log_append_and_print(f"Source download path for models is {self.src_owp_model_folder_path}")
-        self.log_append_and_print(
-            f"Target file name and path for the filtered csv is {self.target_filtered_csv_path}"
-        )
-        self.log_append_and_print(f"Target path for models is {self.target_owp_ras_models_path}")
-        self.log_append_and_print("")
+        self.lprint(f"Source download path for models is {self.src_owp_model_folder_path}")
+        self.lprint(f"Target file name and path for the filtered csv is {self.target_filtered_csv_path}")
+        self.lprint(f"Target path for models is {self.target_owp_ras_models_path}")
+        self.lprint("")
 
     # -------------------------------------------------
     def download_files(self, folder_list):
-        self.log_append_and_print("")
-        self.log_append_and_print("......................................")
+        self.lprint("")
+        self.lprint("......................................")
 
         s3 = s3fs.S3FileSystem()
 
@@ -416,11 +386,12 @@ class Get_Ras_Models_By_Catalog:
         self.num_pending_downloads = len(folder_list)
         self.num_success_downloads = 0
 
+        # Yes.. we are going to use CLI and not boto3
         root_cmd = "aws s3 cp --recursive "
         for folder_name in folder_list:
             num_processed += 1
 
-            self.log_append_and_print("")
+            self.lprint("")
 
             src_path = f"{self.src_owp_model_folder_path}/{folder_name}/"
             print(src_path)
@@ -430,17 +401,17 @@ class Get_Ras_Models_By_Catalog:
             if len(rowIndexes) != 1:
                 msg = "Sorry, something went wrong looking the specific record with a"
                 f"final_name_key of {folder_name}"
-                self.log_append_and_print(f"== {msg}")
+                self.lprint(f"== {msg}")
                 break
 
             rowIndex = rowIndexes[0]
 
             if s3.exists(src_path) is False:
                 msg = f"skipped - s3 folder of {src_path} doesn't exist"
-                self.log_append_and_print(f"== {folder_name}")
-                self.log_append_and_print(f".... {msg}")
+                self.lprint(f"== {folder_name}")
+                self.lprint(f".... {msg}")
                 progress_msg = f">>> {num_processed} of {self.num_pending_downloads} processed"
-                self.log_append_and_print(progress_msg)
+                self.lprint(progress_msg)
 
                 # update the df (csv) to show it failed and why
                 self.df_filtered.loc[rowIndex, MODELS_CATALOG_COLUMN_DOWNLOAD_SUCCESS] = "False"
@@ -448,7 +419,7 @@ class Get_Ras_Models_By_Catalog:
                 continue
 
             target_path = os.path.join(self.target_owp_ras_models_path, folder_name)
-            self.log_append_and_print(f"== {folder_name} - Downloading to path = {target_path}")
+            self.lprint(f"== {folder_name} - Downloading to path = {target_path}")
 
             # cmd = root_cmd + f"{src_path} {target_path} --dryrun"
             # NOTE: we are using subprocesses for now as boto3 can not download folders, only files.
@@ -461,15 +432,15 @@ class Get_Ras_Models_By_Catalog:
 
             cmd = root_cmd + f'"{src_path}" "{target_path}"'
             if self.is_verbose:
-                self.log_append_and_print(f"    {cmd}")
+                self.lprint(f"    {cmd}")
 
             process_s3 = subprocess.run(cmd, capture_output=True, text=True)
             if process_s3.returncode != 0:
                 msg = "*** an error occurred\n"
                 msg += process_s3.stderr
-                self.log_append_and_print(msg)
+                self.lprint(msg)
                 progress_msg = f">>> {num_processed} of {self.num_pending_downloads} processed"
-                self.log_append_and_print(progress_msg)
+                self.lprint(progress_msg)
 
                 # so it doesn't interfer with the delimiter
                 msg = msg.replace(",", " ")
@@ -479,21 +450,21 @@ class Get_Ras_Models_By_Catalog:
                 self.df_filtered.loc[rowIndex, MODELS_CATALOG_COLUMN_DOWNLOAD_FAIL_REASON] = msg
                 continue
 
-            self.log_append_and_print(" ----- successful")
+            self.lprint(" ----- successful")
             self.df_filtered.at[rowIndex, MODELS_CATALOG_COLUMN_DOWNLOAD_SUCCESS] = "True"
 
             # self.df_row[rowIndex] = df_row
             self.num_success_downloads += 1
 
             progress_msg = f">>> {num_processed} of {self.num_pending_downloads} processed"
-            self.log_append_and_print(progress_msg)
+            self.lprint(progress_msg)
 
         return
 
     # -------------------------------------------------
-    def log_append_and_print(self, msg):
+    def lprint(self, msg):
         """
-        Overview  (and Processing Steps)
+        Overview  (and Processing Steps)  (log append and print)
         -----------------------
         This will start a new log object if required and it will stay with the object (self).
         It will keep appending to the log string until it is ready to be output as one
@@ -526,7 +497,7 @@ class Get_Ras_Models_By_Catalog:
         if os.path.exists(self.log_folder_path) is False:
             os.mkdir(self.log_folder_path)
 
-        start_time = datetime.now()
+        start_time = dt.datetime.utcnow()
         file_dt_string = start_time.strftime("%Y%m%d_%H%M%S")
         log_file_path = os.path.join(
             self.log_folder_path, f"get_ras_models_{self.huc_number}-{file_dt_string}.log"
@@ -657,7 +628,7 @@ if __name__ == "__main__":
 
     args = vars(parser.parse_args())
 
-    obj = Get_Ras_Models_By_Catalog()
+    obj = Get_Models_By_Catalog()
     obj.get_models(
         list_only=args["list_only"],
         s3_path_to_catalog_file=args["s3_path_to_catalog_file"],

--- a/tools/ras2fim_to_s3.py
+++ b/tools/ras2fim_to_s3.py
@@ -1,0 +1,876 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime as dt
+import os
+import sys
+import traceback
+
+import boto3
+import pandas as pd
+
+
+sys.path.append("..")
+import s3_shared_functions as s3_sf
+
+import ras2fim.src.shared_functions as sf
+import ras2fim.src.shared_variables as sv
+
+
+"""
+
+NOTE: This script is primarily designed for NOAA/OWP use, but if you have access to your own
+S3, output_ras2fim and output_ras2fim_archive folders, you are welcome to use it. We can not grant access to
+our NOAA / OWP S3 bucket at this time.
+
+To run this tool, you must have already ran 'aws configure' and added creds to the S3 bucket. You should
+find that you only need to setup yoru machine once with 'aws configure' and not each time you use this tool.
+
+
+Overall logic flow:
+
+    - Selecting a single output folder (ie. 12090301_2277_0821) to be selected to 
+      S3. The bucket is definable but not the pathing inside the bucket. It assumes
+      the folders of output_ras2fim and output_ras2fim_archive.  
+    - The incoming folder will check output_ras2fim folder.
+        - If the exact folder name (including huc_crs_date) exist, it will ask the user if they want to:
+            - abort        
+            - overwrite the one in output_ras2fim (likely a mistake or they are redoing it quickly)
+            - re-direct the incoming huc folder directly to output_ras2fim_archive
+
+        - If a folder matching the huc and crs exist (but not the date), it will tell the user if the 
+          existing folder is older or newer then the incoming folder and ask if they want to:
+             - abort
+             - Move the existing folder to output_ras2fim_archive, the upload the new one to
+               output_ras2fim
+             - Re-direct the incoming folder directly to output_ras2fim_archive.
+
+        - If there is no existing folder mathing the huc and crs, just upload it to output_ras2fim
+
+    - A file named ras_output_tracker.csv in the S3:{bucket_name}/output_ras2fim folder will be updated
+      to add a new record of what happened.  The ras_output_tracker.csv is the master and covers all
+      transactions made in relation in uploading new huc_crs folder.
+
+"""
+
+TRACKER_ACTIONS = ["initial_load", "moved_to_arch", "overwriting_prev", "staight_to_arch"]
+
+
+####################################################################
+def save_output_to_s3(src_path_to_huc_crs_output_dir, s3_bucket_name, is_verbose):
+    start_time = dt.datetime.utcnow()
+    dt_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+
+    print("")
+    print("=================================================================")
+    print("          RUN ras2fim_to_s3 ")
+    print(f" (-s): Source huc/crs folder {src_path_to_huc_crs_output_dir} ")
+    print(f" (-b): s3 bucket name {s3_bucket_name}")
+    print(f" Saving HUC/CRS output folder to S3 start: {dt_string} (UTC time) ")
+    print("=================================================================")
+
+    # --------------------
+    # validate input variables and setup key variables
+    varibles_dict = __validate_input(src_path_to_huc_crs_output_dir, s3_bucket_name)
+
+    # why have this come in from variables_dict? the src_path_to_huc_crs_output_dir can come in not
+    # fully pathed, just the huc/crs folder in the default folder path
+    src_path = varibles_dict["src_huc_crs_full_path"]
+    # eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+    huc_crs_folder_name = varibles_dict["src_huc_crs_dir"]
+    # eg. 12030202_102739_230810
+    s3_full_output_path = varibles_dict["s3_full_output_path"]
+    # e.g. s3://xyz/output_ras2fim
+    s3_full_archive_path = varibles_dict["s3_full_archive_path"]
+    # e.g. s3://xyz/output_ras2fim_archive
+    s3_full_huc_crs_path = f"{s3_full_output_path}/{huc_crs_folder_name}"
+    # Note: Generally speaking most values starting with with "s3://xyz" are used for display purposes only
+    # as generaly logic for S3 needs to do it in parts (bucket, and folder). We usually change the
+    # folder values to add in the phrase "output_ras2fim" or "output_ras2fim_archive"
+
+    print("")
+    print(f" --- s3 folder target path is {s3_full_huc_crs_path}")
+    print(f" --- S3 archive folder path (if applicable) is {s3_full_archive_path}")
+    print(f" --- source huc_crs_full_path is {src_path}")
+    print("===================================================================")
+    print("")
+
+    # --------------------
+    # We need to see if the directory already exists in s3.
+    # Depending on what we find will tell us where to uploading the incoming folder
+    # and what to do with pre-existing if there are any pre-existing folders
+    # matching the huc/crs.
+    __upload_to_ras2fim_s3(s3_bucket_name, src_path, huc_crs_folder_name, is_verbose)
+
+    # --------------------
+    print()
+    print("===================================================================")
+    print("Copy to S3 Complete")
+    end_time = dt.datetime.utcnow()
+    dt_string = dt.datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S")
+    print(f"Ended (UTC): {dt_string}")
+
+    # Calculate duration
+    time_duration = end_time - start_time
+    print(f"Duration: {str(time_duration).split('.')[0]}")
+    print()
+
+
+####################################################################
+def __upload_to_ras2fim_s3(bucket_name, src_path, huc_crs_folder_name, is_verbose):
+    """
+    Processing Steps:
+      - Load all first level folder names from that folder. ie) output_ras2fim
+
+      - Get a list for any S3 folder names that match the huc and crs value
+
+      - using the dates for each of the existing s3 huc_crs:
+          - If the incoming date is older or equal to than any pre-existing one, error out
+          - If the incoming date is newer that all pre-existing ones, then move the pre-existing
+            one (or ones) to the archive folder.
+
+        Net results: Only one folder with the HUC/CRS combo an exist in the s3 output folder name
+           and older ones (generally) are all in archives.
+
+       - If we find some that need to be moved, ask the user to confirm before contining (or abort)
+
+       - Any folder moved to archive, will have an addition text added to it, in the form of:
+            _BK_yymmdd_hhmm  (24 hours time.)
+              eg) s3://xyz/output_ras2fim_archive/12030105_2276_230810_BK_230825_1406
+
+    Input
+        - bucket_name: e.g xyz
+        - src_path:  eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+        - huc_crs_folder_name:  12030105_2276_230810
+
+    """
+
+    print("===================================================================")
+    print("Checking existing s3 folders for folders starting with same huc number" " and crs value")
+    print("")
+    print(
+        "** NOTE: The intention is that only one HUC/CRS output folder, usually the most current,"
+        " is kept in the offical output_ras2fim folder. All HUC/CRS folders in the s3 output_ras2fim"
+        "  folder will be included for ras2releases, and duplicate HUC/CRS foldes are likely undesirable."
+    )
+    print("")
+
+    # ---------------
+    # splits it a five part dictionary
+    src_name_dict = s3_sf.parse_huc_crs_folder_name(huc_crs_folder_name)
+    if "error" in src_name_dict:
+        raise Exception(src_name_dict["error"])
+
+    # ---------------
+    # We want only folders that match the huc and crs (don't worry about the date yet).
+    # In theory, it shoudl only find 0 or 1 match as there should only ever be
+    # the latest huc/crs version folder in outputs_ras2fim. But if there are more
+    # than one... something went wrong or someone loaded one directly.
+    s3_huc_crs_folder_names = __get_s3_huc_crs_folder_list(bucket_name, src_name_dict, is_verbose)
+
+    if len(s3_huc_crs_folder_names) > 1:
+        s3_huc_crs_folder_names.sort()
+
+        print("*********************")
+        print("*** NOTE  ")
+        print(
+            "We have detected one or more existing s3 folders with the same HUC and CRS "
+            f"as the new incoming folder name of {huc_crs_folder_name}) at "
+            f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}).\n\n"
+            "Sets of questions will be asked by the program comparing the incoming folder name with each "
+            "of the pre-existing folder names, each one at a time."
+        )
+        print("*********************")
+
+        # ---------------
+        # Figure out the action (by asking the user)
+
+        # All of the s3_huc_crs_folder_names items already share the huc and crs value
+        # but not necessarily the date
+        for s3_existing_folder_name in s3_huc_crs_folder_names:
+            # Now we want the S3 path for the existing folder (without the bucket)
+            # existing_folder_path = f"{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{s3_existing_folder_name}"
+            # eg. outputs_ras2fim/12030105_2276_230303
+
+            existing_name_dict = s3_sf.parse_huc_crs_folder_name(s3_existing_folder_name)
+
+            action = ""
+
+            if existing_name_dict["huc_crs_folder_name"] == src_name_dict["huc_crs_folder_name"]:
+                # exact same folder name including date
+                action = __ask_user_about_dup_folder_name(s3_existing_folder_name, bucket_name)
+
+            # An existing s3_folder has a newer or older date
+            else:
+                if existing_name_dict["key_date_as_dt"] > src_name_dict["key_date_as_dt"]:
+                    is_existing_older = False
+                elif existing_name_dict["key_date_as_dt"] < src_name_dict["key_date_as_dt"]:
+                    is_existing_older = True
+
+                action = __ask_user_about_different_date_folder_name(
+                    huc_crs_folder_name,
+                    bucket_name,
+                    s3_existing_folder_name,
+                    existing_name_dict["key_date_as_str"],
+                    is_existing_older,
+                )
+
+            # --------------------------
+            # Now process the action  (aka we start the uploads to S3 and changes in S3)
+            if action == "overwrite":  # overwrite the pre-existing same named folder with the incoming
+                #  version, we need to delete the original folder so we don't leave junk it int.
+                __overwrite_s3_existing_folder(
+                    src_path, bucket_name, src_name_dict["huc_crs_folder_name"], is_verbose
+                )
+
+            elif action == "archive" or action == "existing":
+                # The words "archive" and "existing" are interchangeable in relations
+                # to process, but differnt words and phrases for the end user's choices.
+                # The two words are used differently in different contexts.
+                # Either way and older folder will be moved to archive and the new one uploaded
+
+                # We will change the name to add on "_BK_yymmdd_hhmm".
+                #  eg) s3://xyz/output_ras2fim_archive/12030105_2276_230810_BK_230825_1406
+                # On the super rare that it was updated in the exact date hr and min, just overwrite it
+
+                # ----------------------
+                # Steps:
+                #     1) Move the existing folder to the archive folder, renaming at as it goes.
+                #
+                #     2) Upload the new incoming folder to outputs_ras2fim
+
+                # Step 1:
+                new_s3_folder_name = __adjust_folder_name_for_archive(s3_existing_folder_name)
+
+                __move_s3_folder_to_archive(
+                    bucket_name, src_path, huc_crs_folder_name, new_s3_folder_name, is_verbose
+                )
+
+                # Step 2:
+                __upload_s3_folder(
+                    bucket_name,
+                    src_path,
+                    huc_crs_folder_name,
+                    TRACKER_ACTIONS[1],
+                    sv.S3_OUTPUT_RAS2FIM_FOLDER,
+                    huc_crs_folder_name,
+                    is_verbose,
+                )
+
+            elif action == "incoming":  # then upload the incoming straight to archive
+                # This option was allowed as the system might find a record that is newer already
+                # existing in the current output_ras2fim. If this happens, the user will be asked
+                # if they want to keep the newer one in output_ras2fim and upload the incoming
+                # straight to archive (or abort)
+
+                new_s3_folder_name = __adjust_folder_name_for_archive(huc_crs_folder_name)
+
+                __upload_s3_folder(
+                    bucket_name,
+                    src_path,
+                    huc_crs_folder_name,
+                    TRACKER_ACTIONS[3],
+                    sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER,
+                    new_s3_folder_name,
+                    is_verbose,
+                )
+
+            else:
+                raise Exception(f"Internal Error: Invalid action type of {action}")
+
+    else:
+        # folder with the same huc_crs doesn't exist and we can load to the output folder
+        """
+        __upload_s3_folder(bucket_name,
+                            src_path,
+                            huc_crs_folder_name,
+                            TRACKER_ACTIONS[0],
+                            sv.S3_OUTPUT_RAS2FIM_FOLDER,
+                            huc_crs_folder_name,
+                            is_verbose)
+        """
+
+
+####################################################################
+def __upload_s3_folder(
+    bucket_name, src_path, orig_folder_name, action, s3_folder_path, new_s3_folder_name, is_verbose
+):
+    """
+    Overview:
+        Upload a folder from local into S3. Sometimes it might be loaded to output_ras2fim
+        or it might be uploaded directly into output_ras2fim_archive
+    Input:
+        - bucket_name:  eg. my_bucket_name  (as  in s3://my_bucket_name)
+        - src_path: serves as a temp place to adjust the s3 tracker csv before re-loading
+            eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+        - orig_folder_name: The original folder name as it started: generally just the
+             huc_crs_date:  eg. 12030202_102739_230810
+        - action: What is happening. Best to use TRACKER_ACTIONS dict (ugly but workable for now)
+        - s3_folder_path: eg. output_ras2fim  or output_ras2fim_archive
+        - new_s3_folder_name: eg. 12030202_102739_230810_BK_230825_1406. It may or may not in the process
+             of having a new folder names as it is being loaded, especially if an incoming upload folder
+             is going straight to archives (which is an option)
+    """
+
+    s3_sf.upload_folder_to_s3(src_path, bucket_name, s3_folder_path, new_s3_folder_name, is_verbose)
+
+    __add_record_to_tracker(
+        bucket_name, src_path, orig_folder_name, action, new_s3_folder_name, s3_folder_path, is_verbose
+    )
+
+
+####################################################################
+def __move_s3_folder_to_archive(bucket_name, src_path, orig_folder_name, target_folder_name, is_verbose):
+    """
+    Overview:
+        Just moving one S3 folder to another place.
+    Input:
+        - bucket_name:  eg. my_bucket_name  (as  in s3://my_bucket_name)
+        - src_path: serves as a temp place to adjust the s3 tracker csv before re-loading
+            eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+        - orig_folder_name:  12030202_102739_230810
+        - target_folder_name: eg. 12030202_102739_230810_BK_230825_1406
+    """
+
+    s3_src_folder_path = f"{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{orig_folder_name}"
+    s3_target_folder_path = f"{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}/{target_folder_name}"
+
+    s3_sf.move_s3_folder_in_bucket(bucket_name, s3_src_folder_path, s3_target_folder_path, is_verbose)
+
+    __add_record_to_tracker(
+        bucket_name,
+        src_path,
+        orig_folder_name,
+        TRACKER_ACTIONS[1],
+        target_folder_name,
+        sv.S3_OUTPUT_RAS2FIM_FOLDER,
+        is_verbose,
+    )
+
+
+####################################################################
+def __overwrite_s3_existing_folder(src_path, bucket_name, huc_crs_folder_name, is_verbose):
+    """
+    Overview:
+        When the system sees the exact same S3 huc_crs_date combination in output_ras2fim,
+        it probably means it was loaded to day by this person or someone else for the same,
+        Maybe they loaded it yesterday, forgot they did it and are try to reload it again.
+        We gave them the option to overwrite the current output_ras2fim folder just in case.
+
+        So we need to delete the existing and reload the new one (same name of course)
+    Inputs:
+        - src_path: eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+        - bucket_name: {your bucket name}
+        - huc_crs_folder_name: eg. 12030202_102739_230810
+
+    """
+    s3_folder_path = f"{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{huc_crs_folder_name}"
+
+    s3_sf.delete_s3_folder(bucket_name, s3_folder_path, is_verbose)
+
+    # Yes.. if it deletes but fails to upload the new one, we have a problem.
+    # TODO: maybe ?? - make a temp copy somewhere (not in archives root folder), then delete
+    #  it from the original existing path, then load the new one, then delete the temp copy.
+    # if upload fails, copy back from temp ??
+
+    s3_sf.upload_folder_to_s3(
+        src_path, bucket_name, sv.S3_OUTPUT_RAS2FIM_FOLDER, huc_crs_folder_name, is_verbose
+    )
+
+    __add_record_to_tracker(
+        bucket_name,
+        src_path,
+        huc_crs_folder_name,
+        TRACKER_ACTIONS[2],
+        huc_crs_folder_name,
+        sv.S3_OUTPUT_RAS2FIM_FOLDER,
+        is_verbose,
+    )
+    # eg, my_bucket_name c:\ras2fim_data\output_ras2fim\12030202_102739_230810,
+    # 12030202_102739_230810, 'overwriting_prev', 12030202_102739_230810,
+    # output_ras2fim, False  (yes. in this case the src and target folder names are the same)
+
+
+####################################################################
+def __adjust_folder_name_for_archive(folder_name):
+    # formatted to S3 convention for archiving
+    # Takes the original name changes it to:
+    # {fold_name}_BK_{utc current date (yymmdd)}_{utc time (HHmm)}
+    #   eg. 12030105_2276_230810_BK_230825_1406
+    # all UTC
+    # Why rename it for the archive folder? we can't have dup folder names
+
+    cur_date = sf.get_stnd_date(True)  # eg. 230825  (in UTC)
+    cur_time = datetime.utcnow().strftime("%H%m")  # eg  2315  (11:15 pm) (in UTC)
+    new_s3_folder_name = f"{folder_name}_BK_{cur_date}_{cur_time}"
+
+    return new_s3_folder_name
+
+
+####################################################################
+# Note: There is enough differnce that I wanted a seperate function for this scenario
+def __ask_user_about_dup_folder_name(huc_crs_folder_name, bucket_name):
+    print()
+    print("*********************")
+
+    msg = (
+        f"You are wanting to upload a folder using the huc/crs of {huc_crs_folder_name}. "
+        "However, a folder of the same name already exists at"
+        f" s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}.\n"
+        "Ensure that other staff has not uploaded the same huc/crs combination today. \n\n"
+        "   -- Type 'overwrite' if you want to overwrite the current folder.\n"
+        "           Note: if you overwrite an existing folder, the s3 version will be deleted first,\n"
+        "           then the new incoming will be loaded.\n\n"
+        "   -- Type 'archive' if you want to move the existing folder in to the archive folder.\n "
+        "   -- Type 'abort' to stop the program.\n"
+        ">>"
+    )
+
+    action = input(msg).lower()
+    if (action) == "abort":
+        print()
+        print(f".. You have selected {action}. Program stopped.")
+        print()
+        sys.exit(0)
+    elif (action) == "overwrite":
+        print()
+        print(f".. You have selected {action}. Folder will be overwritten.")
+        print()
+    elif (action) == "archive":
+        print()
+        print(
+            f".. You have selected {action}. Existing folder will be moved to "
+            f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}."
+        )
+        print()
+    else:
+        print()
+        print(f".. You have entered an invalid value of '{action}'. Program stopped.")
+        print()
+        sys.exit(0)
+
+    return action
+
+
+####################################################################
+# Note: There is enough differnce that I wanted a seperate function for this scenario
+def __ask_user_about_different_date_folder_name(
+    src_huc_crs_folder_name, bucket_name, existing_folder_name, is_existing_older
+):
+    # is_existing_older = True means existing migth be 230814, but target is 230722)
+    # is_existing_older = False means existing migth be 221103, but target is 230816)
+    # if the dates are the same, we handle it in a different function (enough differences)
+
+    print()
+    print("*********************")
+
+    msg = (
+        f"You are wanting to upload a folder using the huc/crs of {src_huc_crs_folder_name}. "
+        "However, a folder of the starting with the same huc and crs already exists as "
+        f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{existing_folder_name}.\n"
+    )
+
+    if is_existing_older is True:
+        msg += "The incoming folder has an older date then the existing folder.\n\n"
+    else:
+        msg += "The incoming folder has an newer date then the existing folder.\n\n"
+
+    msg += (
+        f"Only one can remain in the {sv.S3_OUTPUT_RAS2FIM_FOLDER} folder, the other can be moved "
+        "to the archive folder.\n\n"
+        "... Which of the two do you want to move to archive?\n"
+    )
+    msg += (
+        "   -- Type 'existing' to keep the existing and put the incoming folder straight to archive.\n "
+        "   -- Type 'incoming' to keep the new incoming folder and move the existing one to "
+        "      to the archive folder.\n\n"
+        "   -- Type 'abort' to stop the program.\n"
+        ">>"
+    )
+
+    action = input(msg).lower()
+    if (action) == "abort":
+        print()
+        print(f".. You have selected {action}. Program stopped.")
+        print()
+        sys.exit(0)
+    elif (action) == "incoming":
+        print()
+        print(
+            f".. You have selected {action}. The new incoming folder will be moved to the archive folder at"
+            f" s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}."
+        )
+        print()
+    elif (action) == "existing":
+        print()
+        print(
+            f".. You have selected {action}. The pre-existing folder will be moved to the archive folder at"
+            f" s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}."
+        )
+        print()
+    else:
+        print()
+        print(f".. You have entered an invalid value of '{action}'. Program stopped.")
+        print()
+        sys.exit(0)
+
+    return action
+
+
+####################################################################
+def __get_s3_huc_crs_folder_list(bucket_name, src_name_dict, is_verbose):
+    """
+    Overview
+        This will search the first level path of the s3_folder_path (prefix)
+        for folders that start with the same huc and crs of the incoming target huc_crs
+        folder (target_name_segs).
+
+        It will filter folders to only ones that match the huc and crs
+    Inputs
+        - bucket_name: eg. mys3bucket_name
+        - target_name_segs: a dictionary of the original src huc_crs folder name, split into
+            five keys:
+                key_huc,
+                key_crs_number,
+                key_date_as_str (date string eg: 230811),
+                key_date_as_dt (date obj for 230811)
+                huc_crs_folder_name (12090301_2277_230811) (cleaned version)
+    Output
+        - a list of s3 folders (just folder names not path) that match
+          the starting huc and crs segments
+    """
+
+    s3_huc_crs_folder_names = []
+
+    try:
+        s3 = boto3.client("s3")
+
+        # If the bucket is incorrect, it will throw an exception that already makes sense
+        s3_objs = s3.list_objects_v2(
+            Bucket=bucket_name, Prefix=sv.S3_OUTPUT_RAS2FIM_FOLDER + "/", Delimiter="/"
+        )
+        if is_verbose is True:
+            print("s3_objs is")
+            print(s3_objs)
+
+        if s3_objs["KeyCount"] == 0:
+            return s3_huc_crs_folder_names  # means folder was empty
+
+        # s3 doesn't really use folder names, it jsut makes a key with a long name with slashs
+        # in it.
+        for folder_name_key in s3_objs["CommonPrefixes"]:
+            # comes in like this: output_ras2fim/12090301_2277_230811/
+            # strip of the prefix and last slash so we have straight folder names
+            key = folder_name_key["Prefix"]
+
+            if is_verbose is True:
+                print("--------------------")
+                print(f"key is {key}")
+
+            # strip to the final folder names (but first occurance of the prefix only)
+            key_child_folder = key.replace(sv.S3_OUTPUT_RAS2FIM_FOLDER, "", 1)
+
+            # We easily could get extra folders that are not huc folders, but we will purge them
+            # if it is valid key, add it to a list. Returns a dict.
+            # If it does not match a pattern we want, the first element of the tuple will be
+            # the word error, but we don't care. We only want valid huc_crs_date pattern folders.
+            existing_dic = s3_sf.parse_huc_crs_folder_name(key_child_folder)
+            if "error" in existing_dic:  # if error exists, just skip this one
+                continue
+
+            # see if the huc and crs it matches the incoming huc number and crs
+            if (existing_dic["key_huc"] == src_name_dict["key_huc"]) and (
+                existing_dic["key_crs_number"] == src_name_dict["key_crs_number"]
+            ):
+                s3_huc_crs_folder_names.append(key_child_folder)
+
+        if is_verbose is True:
+            print("huc_crs folders found are ...")
+            print(s3_huc_crs_folder_names)
+
+    except Exception as ex:
+        print("===================")
+        print(f"An critical error has occurred with talking with S3. Details: {ex}")
+        dt_string = dt.datetime.ustnow().strftime("%m/%d/%Y %H:%M")
+        print(f"Ended (UTC time): {dt_string}")
+        raise
+
+    return s3_huc_crs_folder_names
+
+
+####################################################################
+def __add_record_to_tracker(
+    bucket_name, src_huc_crs_full_path, orig_folder_name, cur_action, cur_folder_name, s3_folder, is_verbose
+):
+    """
+    Overview:
+        The s3 tracker csv will add records to the ras_output_tracker.csv that is in
+        S3 output_ras2fim folder. This will only ever add records and never update or
+        delete records.
+
+        Note: if something fails, it will not stop the program unless it is a AWS credentials
+        error.  Anything else wil be displayed to the user and asked to fix it by hand.
+        Why? so we don't try to load the folder / files again into S3.
+
+    Inputs:
+        - bucket_name
+        - src_huc_crs_full_path: local folder of the huc_crs dir being saved up to s3.
+        - orig_folder_name:  eg. 12090301_2276_230815
+        - cur_action: initial_load, moved_to_arch, overwriting_prev  (see TRACKER_ACTIONS)
+        - cur_folder_name: When folders go to the archive directory, it gets a date and time stamp
+          added to the name
+        - s3_folder: the folder it is being moved into (output_ras2fim or output_ras2fim_archive)
+            eg. output_ras2fim or output_ras2fim_archive
+
+        eg: (bucket_name), c:\ras2fim_data\output_ras2fim\12030202_102739_230810, 12030202,
+                102739, 12030202_102739_230810, 'overwriting_prev', 12030202_102739_230810, output_ras2fim, False
+
+        or (bucket_name), c:\ras2fim_data\output_ras2fim\12030202_102739_230810, 12030202,
+                102739, 12030202_102739_230810, 'moved_to_arch', 12030202_102739_230810_BK_230625_1423,
+            output_ras2fim_archive, False
+
+    Outputs:
+        None
+    """
+    # it is in the s3 output_ras2fim
+    s3_path_to_tracker_file = f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{sv.S3_OUTPUT_TRACKER_FILE}"
+
+    try:
+        print()
+        print("*********************")
+        print(f"Updating the s3 tracker file at {s3_path_to_tracker_file}")
+
+        huc_crs_folder_dict = s3_sf.parse_huc_crs_folder_name(orig_folder_name)
+
+        # ----------
+        # calls over to S3 using the aws creds file even though it doesn't use it directly
+        df_cur_tracker = pd.read_csv(s3_path_to_tracker_file, header=0, encoding="unicode_escape")
+
+        # get last tracker ID
+        if len(df_cur_tracker) == 0:
+            next_tracker_id = 1000
+        else:
+            last_tracker_id = df_cur_tracker["tracker_id"].max()
+            next_tracker_id = last_tracker_id + 1
+
+        new_rec = {}  # dictionary
+        new_rec["tracker_id"] = next_tracker_id
+        new_rec["HUC"] = str(huc_crs_folder_dict["key_huc"])
+        new_rec["CRS"] = str(huc_crs_folder_dict["key_crs_number"])
+        new_rec["orig_folder_name"] = orig_folder_name
+
+        dt_stamp = datetime.utcnow().strftime("%m-%d-%Y %H:%M:%S")
+        new_rec["dt_action"] = dt_stamp
+        new_rec["action"] = cur_action
+        new_rec["cur_folder_name"] = cur_folder_name
+        new_rec["cur_s3_folder"] = s3_folder
+
+        df_new_rec = pd.DataFrame.from_records([new_rec])
+
+        # save locally, then copy it up to S3. Yes.. we have a very small chance
+        # of data conflict if both are updating at the same time (pull down versus push)
+
+        # we need to save it temporarily so we will put it in the source huc_crs folder
+        # then delete it once it gets to s3.
+        df_tracker_local_path = os.path.join(src_huc_crs_full_path, sv.S3_OUTPUT_TRACKER_FILE)
+
+        if is_verbose is True:
+            print(f"Saving tracker file to {df_tracker_local_path}")
+
+        # concat original with new record df
+        df_tracker = pd.concat([df_cur_tracker, df_new_rec], ignore_index=True)
+
+        # temp save to file system
+        df_tracker.to_csv(df_tracker_local_path, index=False)
+
+        if is_verbose is True:
+            print("Starting tracker file upload to s3")
+
+        s3_sf.upload_file_to_s3(
+            df_tracker_local_path,
+            bucket_name,
+            sv.S3_OUTPUT_RAS2FIM_FOLDER,
+            sv.S3_OUTPUT_TRACKER_FILE,
+            is_verbose,
+        )
+
+        if is_verbose is True:
+            print("Done upload, removing temp copy")
+
+        os.remove(df_tracker_local_path)
+
+    except Exception as ex:
+        # If anything goes wrong just tell the user to look for it in their src path
+        # and ask them to fix it by hand in S3.
+
+        print("-----------------")
+        print("** Error updating the ras output tracker file to S3. Details:\n")
+        print(traceback.format_exc())
+
+        errMsg = (
+            "\n\nAll applicable files and folder have been loaded to S3, but"
+            f" there was a problem updating the {sv.S3_OUTPUT_TRACKER_FILE} file."
+            " Depending where the error occurred for updating the tracker file,"
+            f" there may be an updated copy in your {src_huc_crs_full_path} folder.\n\n"
+            " Please download the tracker file from S3, make any applicable edits,"
+            " and save it back to S3 as quick as reasonably possible.\n\n"
+            " Please do not simply re-run this script as it will make duplicate copies"
+            " of files and folders in S3."
+        )
+        print(errMsg)
+        print("-----------------")
+
+
+####################################################################
+####  Some validation of input, but also creating key variables ######
+def __validate_input(src_path_to_huc_crs_output_dir, s3_bucket_name):
+    # Some variables need to be adjusted and some new derived variables are created
+    # dictionary (key / pair) will be returned
+
+    rtn_varibles_dict = {}
+
+    # ---------------
+    # why is this here? might not come in via __main__
+    if src_path_to_huc_crs_output_dir == "":
+        raise ValueError("Source huc_crs_output parameter value can not be empty")
+
+    if s3_bucket_name == "":
+        raise ValueError("Bucket name parameter value can not be empty")
+
+    if ("/" in s3_bucket_name) or ("\\" in s3_bucket_name) or ("s3:" in s3_bucket_name):
+        raise ValueError(
+            "Bucket name parameter value invalid. It needs to be a single word"
+            " or phrase such as my_xyz or r2f-dev. It can not contain values such as"
+            " s3: or forward or back slashes"
+        )
+
+    # ---------------
+    # we need to split this to seperate variables.
+    # e.g path_to_huc_crs_output_dir = c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+    #   or 12030202_102739_230810
+
+    # "huc_crs_dir" becomes (if not already) 12030202_102739_230810
+    # "huc_crs_full_path" becomes (if not already) c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+    # remembering that the path or folder name might be different.
+
+    src_path_to_huc_crs_output_dir = src_path_to_huc_crs_output_dir.replace("/", "\\")
+    src_path_segs = src_path_to_huc_crs_output_dir.split("\\")
+    # We need the source huc_crs folder name for later and the full path
+    if len(src_path_segs) == 1:
+        rtn_varibles_dict["src_huc_crs_dir"] = src_path_segs[0]
+        huc_crs_parent_dir = sv.R2F_DEFAULT_OUTPUT_MODELS
+        rtn_varibles_dict["src_huc_crs_full_path"] = os.path.join(
+            huc_crs_parent_dir, rtn_varibles_dict["src_huc_crs_dir"]
+        )
+    else:
+        rtn_varibles_dict["src_huc_crs_dir"] = src_path_segs[-1]
+        # strip of the parent path
+        rtn_varibles_dict["src_huc_crs_full_path"] = src_path_to_huc_crs_output_dir
+
+    if not os.path.exists(rtn_varibles_dict["src_huc_crs_full_path"]):
+        raise ValueError(f"Source HUC/CRS folder not found at {rtn_varibles_dict['src_huc_crs_full_path']}")
+
+    # --------------------
+    # make sure it has a "final" folder and has some contents
+    final_dir = os.path.join(rtn_varibles_dict["src_huc_crs_full_path"], sv.R2F_OUTPUT_DIR_FINAL)
+    if not os.path.exists(final_dir):
+        raise ValueError(
+            f"Source HUC/CRS 'final folder' not found at {final_dir}."
+            " Ensure ras2fim has been run to completion."
+        )
+
+    # check to see that the "final" directory isn't empty
+    file_count = len(os.listdir(final_dir))
+    if file_count == 0:
+        raise ValueError(
+            f"Source HUC/CRS 'final folder' at {final_dir}" " does not appear to have any files or folders."
+        )
+
+    # --------------------
+    # check ras2fim output bucket exists
+
+    print()
+    print(f"Validating that the s3 bucket of {s3_bucket_name} exists")
+    if s3_sf.does_s3_bucket_exist(s3_bucket_name) is False:
+        raise ValueError(f"{s3_bucket_name} does not exist")
+    else:
+        print(".... found")
+
+    # --------------------
+    # check ras2fim bucket folder
+    s3_full_output_path = f"s3://{s3_bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}"
+    print()
+    print(f"Validating S3 output folder of {s3_full_output_path}")
+
+    # it will throw an error if it does not exist
+    s3_sf.is_valid_s3_folder(s3_full_output_path)  # don't care about return values here
+    print(".... found")
+    rtn_varibles_dict["s3_full_output_path"] = s3_full_output_path
+
+    # --------------------
+    # check ras2fim archive bucket folder
+    s3_full_archive_path = f"s3://{s3_bucket_name}/{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}"
+    print()
+    print(f"Validating S3 archive folder of {s3_full_archive_path}")
+    s3_sf.is_valid_s3_folder(s3_full_archive_path)  # don't care about return values here
+    print(".... found")
+    rtn_varibles_dict["s3_full_archive_path"] = s3_full_archive_path
+
+    return rtn_varibles_dict
+
+
+if __name__ == "__main__":
+    # ---- Samples Inputs
+    # 1) Using default pathing:
+    #    python /tools/ras2fim_to_s3.py -s 12030202_102739_230810 -b xyz_bucket
+    #        The default path will make this bec
+
+    # 2) Using full pathing:
+    #    python /tools/ras2fim_to_s3.py -s c:\my_ras\output\12030202_102739_230810 -b xyz_bucket
+
+    # NOTE: pathing inside the bucket can not be changed.
+    # The root folder (prefix) is hardcoded to output_ras2fim and the archive folder is
+    # hardcoded to output_ras2fim_archive.
+    # This will help preserve other tools that are relying on specific s3 pathing.
+    # The folder name from the source folder (not path) will automatically becomes the s3 folder name.
+
+    parser = argparse.ArgumentParser(
+        description="Saving ras2fim HUC/CRS output folders back to S3",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-s",
+        "--src_path_to_huc_crs_output_dir",
+        help="REQUIRED: Can be used in two ways:\n"
+        "1) Add just the output huc_crs folder name (assumed default pathing)\n"
+        "2) A full defined path including output huc_crs folder\n"
+        " ie) c:\my_ras\output\\12030202_102739_230810\n"
+        "  or just 12030202_102739_230810",
+        required=True,
+        metavar="",
+    )
+
+    # s3 bucket name. Can't default S3 paths due to security.  ie) xyz  of (s3://xyz)
+    parser.add_argument(
+        "-b",
+        "--s3_bucket_name",
+        help="REQUIRED: S3 bucket where output ras2fim folders are placed.\n"
+        "eg) xyz_bucket from s3://xyz_bucket",
+        required=True,
+        metavar="",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--is_verbose",
+        help="OPTIONAL: Adding this flag will give additional tracing output."
+        "Default = False (no extra output)",
+        required=False,
+        default=False,
+        action="store_true",
+    )
+
+    args = vars(parser.parse_args())
+
+    save_output_to_s3(**args)

--- a/tools/ras_unit_to_s3.py
+++ b/tools/ras_unit_to_s3.py
@@ -720,7 +720,7 @@ def __add_record_to_tracker(
             print("Starting tracker file upload to s3")
 
         s3_sf.upload_file_to_s3(
-            bucket_name, df_tracker_local_path, sv.S3_OUTPUT_RAS2FIM_FOLDER, sv.S3_OUTPUT_TRACKER_FILE
+            bucket_name, df_tracker_local_path, sv.S3_OUTPUT_RAS2FIM_FOLDER, sv.S3_OUTPUT_TRACKER_FILE, False
         )
 
         if is_verbose is True:

--- a/tools/s3_shared_functions.py
+++ b/tools/s3_shared_functions.py
@@ -19,7 +19,7 @@ import shared_variables as sv
 
 
 ####################################################################
-def upload_file_to_s3(bucket_name, src_path, s3_folder_path, file_name=""):
+def upload_file_to_s3(bucket_name, src_path, s3_folder_path, file_name="", show_upload_msg=True):
     """
     Overview:
         This file upload will overwrite an existing file it if already exists. Use caution
@@ -56,7 +56,9 @@ def upload_file_to_s3(bucket_name, src_path, s3_folder_path, file_name=""):
 
         with open(src_path, "rb"):
             client.upload_file(src_path, bucket_name, s3_key_path)
-            print(f".... File uploaded {src_path} as {s3_full_target_path}/{s3_file_name}")
+
+            if show_upload_msg is True:
+                print(f".... File uploaded {src_path} as {s3_full_target_path}/{s3_file_name}")
 
     except botocore.exceptions.NoCredentialsError:
         print("-----------------")

--- a/tools/s3_shared_functions.py
+++ b/tools/s3_shared_functions.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from datetime import datetime
+
+
+sys.path.append("..")
+import boto3
+import botocore.exceptions
+from botocore.client import ClientError
+from tqdm import tqdm
+
+import ras2fim.src.shared_variables as sv
+
+
+####################################################################
+def upload_file_to_s3(src_path, bucket_name, s3_folder_path, file_name="", is_verbose=False):
+    """
+    Overview:
+        This file upload will overwrite an existing file it if already exists. Use caution
+
+    Input
+        - src_path: e.g c:\ras2fim_data\output_ras2fim\my_file.csv
+        - bucket_name: e.g mys3bucket_name
+        - s3_folder_path: e.g.  output_ras2fim or temp\robh
+        - file_name: If this is empty, then the file name from the source
+            will be used. Otherwise, this becomes the new files name in S3
+
+    """
+
+    # yes.. outside the try/except
+    if not os.path.exists(src_path):
+        raise FileNotFoundError(src_path)
+
+    try:
+        if file_name == "":
+            # strip it out the source name
+            s3_file_name = os.path.basename(src_path)
+        else:
+            s3_file_name = file_name
+
+        # safety feature in case we have more than one foreward slash as that can
+        # be a mess in S3 (it will honor all slashs)
+        s3_folder_path = s3_folder_path.replace("//", "/")
+
+        s3_full_target_path = f"s3://{bucket_name}/{s3_folder_path}"
+        if is_verbose is True:
+            print(f".. s3 target path is {s3_full_target_path}")
+
+        s3_key_path = f"{s3_folder_path}/{s3_file_name}"
+
+        client = boto3.client("s3")
+
+        with open(src_path, "rb"):
+            # s3.Bucket(bucket_name).put_object(Key=s3_key_path, Body=data)
+            client.upload_file(src_path, bucket_name, s3_key_path)
+            if is_verbose is True:
+                print(f".... File uploaded {src_path} as {s3_full_target_path}/{s3_file_name}")
+
+    except botocore.exceptions.NoCredentialsError:
+        print("-----------------")
+        print(
+            "** Credentials not available for the submitted bucket. Try aws configure or review AWS "
+            "permissions options."
+        )
+        sys.exit(1)
+
+    except Exception as ex:
+        print("-----------------")
+        print("** Error uploading file to S3:")
+        raise ex
+
+
+####################################################################
+def upload_folder_to_s3(src_path, bucket_name, s3_folder_path, huc_crs_folder_name, is_verbose):
+    """
+    Input
+        - src_path: e.g c:\ras2fim_data\output_ras2fim\12030202_102739_230810
+        - bucket_name: e.g mys3bucket_name
+        - s3_folder_path: e.g.  output_ras2fim or output_ras2fim_archive
+        - target_huc_crs_folder_name:  12030105_2276_230810 (slash stripped off the end)
+    """
+
+    print("===================================================================")
+    print("")
+
+    try:
+        # we are going to walk it twice, once to get a file count, the other for TQDM processing
+        file_count = 0
+        for subdir, dirs, files in os.walk(src_path):
+            file_count += len(files)
+
+        client = boto3.client("s3")
+
+        with tqdm(
+            total=file_count,
+            desc=f"Uploading {file_count} files to S3",
+            bar_format="{desc}:({n_fmt}/{total_fmt})|{bar}| {percentage:.1f}%",
+            ncols=80,
+            disable=is_verbose,
+        ) as pbar:
+            for subdir, dirs, files in os.walk(src_path):
+                for file in files:
+                    # don't let it upload a local copy of the tracker file
+                    # if it happens to exist in the source folder.
+                    if sv.S3_OUTPUT_TRACKER_FILE in file:
+                        pbar.update(1)
+                        continue
+
+                    # print(f".. src file = {file}")
+                    src_file_path = os.path.join(src_path, subdir, file)
+                    if is_verbose is True:
+                        print("-----------------")
+                        print(f".. src file_path = {src_file_path}")
+
+                    src_ref_path = subdir.replace(src_path, "")
+
+                    # switch the slash
+                    src_ref_path = src_ref_path.replace("\\", "/")
+                    # s3_key_path = s3_folder_path + src_ref_path + '/' + file
+                    s3_key_path = f"{s3_folder_path}/{huc_crs_folder_name}/{src_ref_path}/{file}"
+                    # safety feature in case we have more than one foreward slash as that can
+                    # be a mess in S3 (it will honor all slashs)
+                    s3_key_path = s3_key_path.replace("//", "/")
+
+                    s3_full_target_path = f"s3://{bucket_name}/{s3_key_path}"
+                    if is_verbose is True:
+                        print(f".. s3 target path is {s3_full_target_path}")
+
+                    try:
+                        with open(src_file_path, "rb"):
+                            # s3.Bucket(bucket_name).put_object(Key=s3_key_path, Body=data)
+                            client.upload_file(src_file_path, bucket_name, s3_key_path)
+                            if is_verbose is True:
+                                print(".... File uploaded")
+
+                    except FileNotFoundError:
+                        print("-----------------")
+                        print(f"** The file {src_file_path} was not found")
+                        print(
+                            "** This is considered a critical error as the file name was"
+                            " found programatically."
+                        )
+                        sys.exit(1)
+
+                    pbar.update(1)
+
+    except botocore.exceptions.NoCredentialsError:
+        print("-----------------")
+        print(
+            "** Credentials not available for the submitted bucket. Try aws configure or review AWS "
+            "permissions options."
+        )
+        sys.exit(1)
+
+    except Exception as ex:
+        print("-----------------")
+        print("** Error uploading files to S3:")
+        raise ex
+
+
+####################################################################
+def delete_s3_folder(bucket_name, s3_folder_path, is_verbose):
+    """
+    Overview:
+        Sometimes we want to delete s3 folder before loading a replacement.
+        Why not just overwrite? It can leave old unwanted files.
+        Technically, you can't delete a folder, just all of the objects in a prefix path.
+
+    Input:
+        - bucket_name: e.g mys3bucket_name
+        - s3_folder_path: e.g.  temp/rob/12030105_2276_230810  (or output_ras2fim)
+    """
+
+    s3_full_target_path = f"s3://{bucket_name}/{s3_folder_path}"
+
+    print("===================================================================")
+    print("")
+    print(f"Deleting the files and folder at {s3_full_target_path}")
+
+    try:
+        client = boto3.client("s3")
+
+        # Files inside the folder (yes.. technically there are no folders)
+        # but it is possible to a folder that is empty (prefix with no keys)
+        s3_files = client.list_objects(Bucket=bucket_name, Prefix=s3_folder_path + "/")
+
+        file_count = len(s3_files)
+
+        if file_count == 0:  # no files to delete but it is possible to have an empty folder
+            client.delete_object(Bucket=bucket_name, Key=s3_folder_path + "/")  # slash added
+
+        with tqdm(
+            total=file_count,
+            desc=f"Deleting {file_count} files from S3",
+            bar_format="{desc}:({n_fmt}/{total_fmt})|{bar}| {percentage:.1f}%",
+            ncols=80,
+            disable=is_verbose,
+        ) as pbar:
+            # Delete all objects in the folder
+            for s3_file in s3_files["Contents"]:
+                client.delete_object(Bucket=bucket_name, Key=s3_file["Key"])
+
+            pbar.update(1)
+
+        # remove the folder that is left over
+        client.delete_object(Bucket=bucket_name, Key=s3_folder_path + "/")  # slash added
+
+    except botocore.exceptions.NoCredentialsError:
+        print("-----------------")
+        print("** Credentials not available. Try aws configure or review AWS permissions options.")
+        sys.exit(1)
+
+    except Exception as ex:
+        print("-----------------")
+        print(f"** Error deleting files at S3: {ex}")
+    raise ex
+
+
+####################################################################
+def move_s3_folder_in_bucket(bucket_name, s3_src_folder_path, s3_target_folder_path, is_verbose):
+    """
+    Overview:
+        To move an S3 folder, we have to copy all of it's objects recursively
+        then delete the original folder objects
+
+    Input:
+        - bucket_name: e.g mys3bucket_name
+        - s3_src_folder_path: e.g. output_ras2fim/12030105_2276_230810
+        - s3_target_folder_path: e.g.  output_ras2fim_archive/12030105_2276_230810
+    """
+    try:
+        print("===================================================================")
+        print("")
+        print(f"Moving folder from {s3_src_folder_path} to {s3_target_folder_path}")
+
+        client = boto3.client("s3")
+
+        # use paginator as it can handle more than the 1000 file limit max from list_objects_v2
+        paginator = client.get_paginator("list_objects_v2")
+        operation_parameters = {"Bucket": bucket_name, "Prefix": s3_src_folder_path}
+
+        page_iterator = paginator.paginate(**operation_parameters)
+
+        file_count = len(page_iterator)
+
+        with tqdm(
+            total=file_count,
+            desc=f"Moving {file_count} files in S3",
+            bar_format="{desc}:({n_fmt}/{total_fmt})|{bar}| {percentage:.1f}%",
+            ncols=80,
+            disable=is_verbose,
+        ) as pbar:
+            for page in page_iterator:
+                print(page["Contents"])
+                if "Contents" in page:
+                    for key in page["Contents"]:
+                        keyString = key["Key"]
+                        print(keyString)
+                        pbar.update(1)
+
+        """
+        # If the bucket is incorrect, it will throw an exception that already makes sense
+        s3_src_objs = client.list_objects_v2(Bucket=bucket_name, Prefix=s3_src_folder_path)
+        
+        if s3_src_objs["KeyCount"] == 0:
+            print(f"No files in source folder of {s3_src_folder_path}. Move invalid.")
+            return
+        
+        source_key = s3_src_objs["Contents"][0]["Key"]
+
+        copy_source = {'Bucket': bucket_name, 'Key': s3_src_folder_path}
+
+        client.copy_object(Bucket = bucket_name, CopySource = copy_source, Key = old_key_name + your_destination_file_name)
+
+        # s3 doesn't really use folder names, it jsut makes a key with a long name with slashs
+        # in it.
+        for folder_name_key in s3_src_objs.get("CommonPrefixes"):
+            # comes in like this: output_ras2fim/12090301_2277_230811/
+            # strip of the prefix and last slash so we have straight folder names
+            key = folder_name_key["Prefix"]
+
+            if is_verbose is True:
+                print("--------------------")
+                print(f"key is {key}")
+
+            # strip to the final folder names (but first occurance of the prefix only)
+            key_child_folder = key.replace(sv.S3_OUTPUT_RAS2FIM_FOLDER, "", 1)
+
+            # We easily could get extra folders that are not huc folders, but we will purge them
+            # if it is valid key, add it to a list. Returns a dict.
+            # If it does not match a pattern we want, the first element of the tuple will be
+            # the word error, but we don't care. We only want valid huc_crs_date pattern folders.
+            existing_dic = s3_sf.parse_huc_crs_folder_name(key_child_folder)
+            if 'error' in existing_dic: # if error exists, just skip this one
+                continue
+
+            # see if the huc and crs it matches the incoming huc number and crs
+            if (existing_dic['key_huc'] == src_name_dict['key_huc']) and (
+                existing_dic['key_crs_number'] == src_name_dict['key_crs_number']
+            ):
+                s3_huc_crs_folder_names.append(key_child_folder)
+
+        if is_verbose is True:
+            print("huc_crs folders found are ...")
+            print(s3_huc_crs_folder_names)
+            """
+
+    except botocore.exceptions.NoCredentialsError:
+        print("-----------------")
+        print(
+            "** Credentials not available for the submitted bucket. Try aws configure or review AWS "
+            "permissions options."
+        )
+        sys.exit(1)
+
+    except Exception as ex:
+        print("-----------------")
+        print("** Error moving folders in S3:")
+        raise ex
+
+
+####################################################################
+def is_valid_s3_folder(s3_bucket_and_folder):
+    # This will throw exceptions for all errors
+
+    if s3_bucket_and_folder.endswith("/"):
+        s3_bucket_and_folder = s3_bucket_and_folder[:-1]
+
+    # we need the "s3 part stripped off for now" (if it is even there)
+    adj_s3_path = s3_bucket_and_folder.replace("s3://", "")
+    path_segs = adj_s3_path.split("/")
+    bucket_name = path_segs[0]
+    s3_folder_path = adj_s3_path.replace(bucket_name, "", 1)
+    s3_folder_path = s3_folder_path.lstrip("/")
+
+    client = boto3.client("s3")
+
+    try:
+        # If the bucket is incorrect, it will throw an exception that already makes sense
+        s3_objs = client.list_objects_v2(Bucket=bucket_name, Prefix=s3_folder_path, MaxKeys=2, Delimiter="/")
+
+        # assumes the folder exists and has values ??
+        # print(s3_objs)
+        if s3_objs["KeyCount"] == 0:
+            raise ValueError(
+                "S3 bucket exists but the folder path does not exist and is required. "
+                "Path is case-sensitive"
+            )
+
+    except ValueError:
+        # don't trap these types, just re-raise
+        raise
+
+    except botocore.exceptions.NoCredentialsError:
+        print("** Credentials not available. Try aws configure.")
+    except Exception as ex:
+        print(f"An error has occurred with talking with S3; Details {ex}")
+
+    return bucket_name, s3_folder_path
+
+
+####################################################################
+def does_s3_bucket_exist(bucket_name):
+    client = boto3.client("s3")
+
+    try:
+        client.head_bucket(Bucket=bucket_name)
+        # resp = client.head_bucket(Bucket=bucket_name)
+        # print(resp)
+
+        return True  # no exception?  means it exist
+
+    except botocore.exceptions.NoCredentialsError:
+        print("** Credentials not available for submitted bucket. Try aws configure.")
+        sys.exit(1)
+
+    except client.exceptions.NoSuchBucket:
+        return False
+
+    except ClientError:
+        return False
+
+    # other exceptions can be passed through
+
+
+####################################################################
+def parse_huc_crs_folder_name(huc_crs_folder_name):
+    """
+    Overview:
+        While all uses of this function pass back errors if invalid the calling code can decide if it is
+        an exception. Sometimes it doesn't, it just want to check to see if the key is a huc crs key.
+
+    Input:
+        huc_crs_folder_name: migth be a full s3 string, or a s3 key or just the folder name
+           e.g.  s3://xzy/output_ras2fim/12090301_2277_230811
+              or output_ras2fim/12090301_2277_230811
+              or 12090301_2277_230811
+
+    Output:
+        A dictionary with records of:
+                       key_huc,
+                       key_crs_number,
+                       key_date_as_str (date string eg: 230811),
+                       key_date_as_dt  (date obj for 230811)
+                       huc_crs_folder_name (12090301_2277_230811) (cleaned version)
+        OR
+        If in error, dictionary will have only one key of "error", saying why it the
+           reason for the error. It lets the calling code to decide if it wants to raise
+           and exception.
+           Why? There are some incoming folders that will not match the pattern and the
+           calling code will want to know that and may just continue on
+
+        BUT: if the incoming param doesn't exist, that raises an exception
+    """
+
+    rtn_varibles_dict = {}
+
+    if huc_crs_folder_name == "":
+        raise ValueError("huc_crs_folder_name can not be empty")
+
+    # cut off the s3 part if there is any.
+    huc_crs_folder_name = huc_crs_folder_name.replace("s3://", "")
+
+    # s3_folder_path and we want to strip the first one only. (can be deeper levels)
+    if huc_crs_folder_name.endswith("/"):
+        huc_crs_folder_name = huc_crs_folder_name[:-1]  # strip the ending slash
+
+    # see if there / in it and split out based on the last one (migth not be one)
+    huc_crs_folder_segs = huc_crs_folder_name.rsplit("/", 1)
+    if len(huc_crs_folder_segs) > 1:
+        huc_crs_folder_name = huc_crs_folder_segs[-1]
+
+    # The best see if it has an underscore in it, split if based on that, then
+    # see the first chars are an 8 digit number and that it has two underscores (3 segs)
+    # and will split it to a list of tuples
+    if "_" not in huc_crs_folder_name or len(huc_crs_folder_name) < 9:
+        rtn_varibles_dict["error"] = "Does not contain any underscore or folder name to short."
+        return rtn_varibles_dict
+
+    segs = huc_crs_folder_name.split("_")
+    if len(segs) != 3:
+        rtn_varibles_dict["error"] = (
+            "Expected three segments split by two underscores." "e.g . 12090301_2277_230811"
+        )
+        return rtn_varibles_dict
+
+    key_huc = segs[0]
+    key_crs = segs[1]
+    key_date = segs[2]
+
+    if (not key_huc.isnumeric()) or (not key_crs.isnumeric()) or (not key_date.isnumeric()):
+        rtn_varibles_dict["error"] = "All three segments are expected to be numeric."
+        return rtn_varibles_dict
+
+    if len(key_huc) != 8:
+        rtn_varibles_dict["error"] = "First part of the three segments (huc) is not 8 digits long."
+        return rtn_varibles_dict
+
+    if (len(key_crs) < 4) or (len(key_crs) > 6):
+        rtn_varibles_dict["error"] = (
+            "Second part of the three segments (crs) is not" " between 4 and 6 digits long."
+        )
+        return rtn_varibles_dict
+
+    if len(key_date) != 6:
+        rtn_varibles_dict["error"] = "Last part of the three segments (date) is not 6 digits long."
+        return rtn_varibles_dict
+
+    # test date format
+    # format should come in as yymmdd  e.g. 230812
+    # If successful, the actual date object be added
+    dt_key_date = None
+    try:
+        dt_key_date = datetime.strptime(key_date, "%y%m%d")
+    except Exception:
+        rtn_varibles_dict["error"] = (
+            "Last part of the three segments (date) does not appear"
+            " to be in the pattern of yymmdd eg 230812"
+        )
+        return rtn_varibles_dict
+
+    rtn_varibles_dict["key_huc"] = key_huc
+    rtn_varibles_dict["key_crs_number"] = key_crs
+    rtn_varibles_dict["key_date_as_str"] = key_date
+    rtn_varibles_dict["key_date_as_dt"] = dt_key_date
+    rtn_varibles_dict["huc_crs_folder_name"] = huc_crs_folder_name  # cleaned version
+
+    return rtn_varibles_dict


### PR DESCRIPTION
This PR includes a new tool that can take a ras2fim unit output folder and upload it to S3. During that upload processes, it checks the s3 `output_ras2fim` folder to look for folders already share the same huc and crs values. A folder may/may not pre-exist that matches the huc and crs but may/may not share a date.  A new master file called `ras_output_tracker.csv` exists now in the s3 `output_ras2fim` folder which tracks all folders uploaded, moved to archive, and overwritten. All activities done by the new `ras_unit_to_s3.py` update this new master copy in S3.

The s3 `output_ras2fim` folder is intended to have only folder with a given huc and crs and would almost always be the latest version.  All other versions would be renamed to the phrase of "_BK_" and a date and moved into the `output_ras2fim_archive` folder. 

There are some combinations where a user can overwrite older folders or simply move incoming folder straight to the archive folder.   Lots of output including input question to the user with choices of aborting, moving existing folders and other options.

Other small fixes include:
- [issue 152](https://github.com/NOAA-OWP/ras2fim/issues/152), which changes all ras2fim code to use UTC times.
- [issue 111](https://github.com/NOAA-OWP/ras2fim/issues/111) to fix is to make use of a previously added method which can validate a CRS when it comes in as an input arg to a file. This has now been applied to both `ras2fim.py` and `get_models_by_catalog.py`.
- `get_models_by_catalog.py` was renamed from its previous name of `get_ras_models_by_catalog.py`. It was also adjusted for an additional filter as per change in pre-processing (RRASSLER team).
- change all files with used multi-proc or multi-threading to be cpu proc count - 2 (used to be -1 and it was leaving machines without not enough cpu's to handle other tasks. It was especially noticed when debugging and needed to use Task Manager and it was bogging down the system badly.
- some small misc cleanup on a few files such as a bit of variable and function renaming, output and formatting.

### Additions  
- `tools`
   - `ras_unit_to_s3.py`: As described above.
   - `s3_shared_functions.py`:  A file to manage all communication with S3, upload, deleted, move, etc. It does not yet have a download function but it will likely be added and plugged into `get_models_by_catalog.py` at a later date. However, other tools that are coming soon can use these same functions.

### Changes  
- `pyproject.toml`: Added a few adjustments to the pre-file-ignores section.
- `src`
    - `calculate_all_terrain_stats.py`: Change multi-proc / number of workers count as mentioned above.
    - `conflate_hecras_to_nwm.py`: Change multi-proc / number of workers count as mentioned above.
    - `create_fim_rasters.py`: Change multi-proc / number of workers count as mentioned above.
    - `create_geocurves.py`: Change multi-proc / number of works and changed date time to UTC.
    - `create_shapes_from_hecras.py` Change multi-proc / number of works and comments on non standard linting issue.
    - `ras2catchment.py`: Change multi-proc / number of works and changed date time to UTC.
    - `ras2fim.py`: Changes include: 
         - Renamed a few variables to be more descriptive.
         - Small changes the argument log file.
         - Small change to track each section being processed by ensuring they have the word `step` in the header (not necessarily followed by a number). This allows for easier searching of the screen output for section headers.
         - Change multi-proc / number of works and changed date time to UTC.
     - `reformat_ras_rating_curve.py`: Change multi-proc / number of workers count as mentioned above.
     - `run_ras2rem.py`: Change multi-proc / number of workers count as mentioned above.
     - `shared_functions.py`: Moved the print_date_time_duration location in the file.  Added a test that a models folder existed when it was looking to get the projection from ras_proj. Why? It was possible to have invalid values folders or pathing in ras2fim.py and was creating issues on rare occasions (but it happened). Also changed date time to UTC.
     - `shared_validators.py`: text adjustment
     - `shared_variables.py`: add three new variables for S3.
     - `simplify_fim_rasters.py`: Change multi-proc / number of workers count as mentioned above.
     - `worker_fim_rasters.py`: Linting fix.
 - `tools`
     - `get_ras_models_by_catalog.py` renamed to `get_models_by_catalog.py`
     - `get_models_by_catalog.py:  renamed a page level function name. Changed to UTC time. Added "3_" as a new skip filter for downloading model folders. Removed code to validate incoming CRS value to use the `shared_validators.py` version.

### Testing

The new tool has a number of possibilities that can occur while uploading to S3, especially with attempting to keep only the latest version of a unit (huc and crs).  The s3 `output_ras2fim` should now keep only the latest editions that can be bundled up and given to HV or other teams as when needed by the `ras2release` tool coming later.

To setup the start of the test, I made unit folder from ras2fim.py with some models. I happened to have a full scale output set with all models for 12030105 with 22,000 files.  I used a full scale to also test multi-threading (not multi-proc), to check performance. Uploading and moving of folders in S3 take anywhere from 1 to 5 mins with a set of 22,000 files.

I made sure all tests pointed to our ras2fim-dev repo and NOT the production version of ras2fim.

My tests: (with each test I would download the `ras_output_tracker.csv` in the dev repo to ensure it added activity records correctly). The order of these tests I did was critical.

- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_**230908** -b ras2fim-dev`  - First time upload of a unit with a huc-crs with a date of 230908.
- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_**230908** -b ras2fim-dev` - Uploaded the same unit folder with same date which already exists now in S3, but selected to overwrite the existing one.
- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_**230908** -b ras2fim-dev` - Uploaded the same unit folder with same date which already exists now in S3, but told it to archive the existing one (to the archive folder) and upload the new one to outputs.
- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_**230915** -b ras2fim-dev` - Uploaded a unit with the same huc-crs but a newer date then what was already in S3. I told it to send the new incoming directly to archive. Opened up this option as the one in S3 may be older or newer then the incoming one.  That is possible if people load directly to S3 instead of using the tool and/or mistakes can happen.  Users can sort it out later if needed too.
- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_**230915** -b ras2fim-dev` - Uploaded a unit with the same huc-crs but with the 230915 date. At this point, the 230908 is still there, so I told it to archive the old one and upload the new one.

The tool has the ability to see if two or more folders already exist in S3 outputs folder and the tool can handle this. To test it, I had the 230915 folder already in S3 by previous tests, but used aws cli to upload another folder (230904) directly into S3. Now I have two huc-crs folders in outputs which is invalid. Then I ran the tool attempting to upload yet a newer edition (230917). 
- `python ./tools/ras_unit_to_s3.py -s 12030105_2276_230917 -b ras2fim-dev`.  It advised me it would move both existing folders regardless of date into the archive folder and upload the new one. 

Every combination of using the new ras to s3 tool has an abort option which was also tested.

To help validate that a folder was uploaded correctly, I was constantly downloading the tracker file and viewing it, but I also used a tool in aws web console to get a folder count and folder size and ensure they match the source count and sizes. To do this, see the following image.

![image](https://github.com/NOAA-OWP/ras2fim/assets/90854818/a9c2b00f-d49e-4e5a-82ea-ad5daa340034)

![image](https://github.com/NOAA-OWP/ras2fim/assets/90854818/79c4d18e-05a0-4830-865e-d4d2a6e81bcd)


### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Pre-commit executed and linting changes made.
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)

### Merge Checklist (For Technical Lead use only)

- [x] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
