### PR TITLE
[1pt] PR: Fix bug in ras unit to s3

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,8 +1,24 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v2.0.beta.x - 2023-11-15 - [PR#208](https://github.com/NOAA-OWP/ras2fim/pull/208)
 
-## v1.30.1 - 2023-11-2 - [PR#166](https://github.com/NOAA-OWP/ras2fim/pull/198)
+During a recent other merge, ras_unit_to_s3 began failing to upload. Now fixed.
+
+### Changes  
+- `src`/`shared_validators.py`: corrected text.
+- `tools`
+    - `ras_unit_to_s3.py`: Fix upload bug which was based in the `skip_files` system which exempts some files from  uploading to S3. Also added color to console as questions are asked of the user (live input). 
+    - `s3_shared_functions.py`:  Removed progress bars which don't work well now with RLOG. . Fixed the `skip_files` system. Added color in key screen outputs for readability. Added throttling on max number of CPU's for multi-thread.
+
+<br/><br/>
+
+## ================================================
+## Note: Below is the end of the V1 Series. Moving forward will be towards the new V2 ras2fim series.
+
+<br/><br/>
+
+## v1.30.1 - 2023-11-2 - [PR#198](https://github.com/NOAA-OWP/ras2fim/pull/198)
 
 This PR fixes a small bug for making polygons for model domains that results in reporting all models to be not-conflated to NWM reaches. This PR closes #195.
 

--- a/src/shared_validators.py
+++ b/src/shared_validators.py
@@ -34,7 +34,7 @@ def is_valid_crs(crs):
     err_msg = ""
 
     if crs == "":
-        err_msg = "huc number is not eight characters in length"
+        err_msg = "The crs value can not be blank or empty"
         return False, err_msg, ""
 
     if ":" not in crs:

--- a/tools/ras_unit_to_s3.py
+++ b/tools/ras_unit_to_s3.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 
 import boto3
+import colored as cl
 import pandas as pd
 
 
@@ -103,7 +104,11 @@ def unit_to_s3(src_unit_dir_path, s3_bucket_name, is_verbose):
 
     global TRACKER_SRC_LOCAL_PATH
     TRACKER_SRC_LOCAL_PATH = os.path.join(src_unit_dir_path, sv.S3_OUTPUT_TRACKER_FILE)
-    upload_skip_files = [
+
+    # These are files that will not be uploaded to S3
+    # Note: Will upload log files from original process such as ras2fim files
+    # but not the logs files being created as part of ras_unit_to_s3 logs
+    skip_files = [
         TRACKER_SRC_LOCAL_PATH,
         RLOG.LOG_FILE_PATH,
         RLOG.LOG_WARNING_FILE_PATH,
@@ -121,7 +126,7 @@ def unit_to_s3(src_unit_dir_path, s3_bucket_name, is_verbose):
     # Depending on what we find will tell us where to uploading the incoming folder
     # and what to do with pre-existing if there are any pre-existing folders
     # matching the huc/crs.
-    __process_upload(s3_bucket_name, src_path, unit_folder_name, upload_skip_files, is_verbose)
+    __process_upload(s3_bucket_name, src_path, unit_folder_name, skip_files, is_verbose)
 
     # --------------------
     RLOG.lprint("")
@@ -138,7 +143,7 @@ def unit_to_s3(src_unit_dir_path, s3_bucket_name, is_verbose):
 
 
 ####################################################################
-def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files, is_verbose):
+def __process_upload(bucket_name, src_path, unit_folder_name, skip_files, is_verbose):
     """
     Processing Steps:
       - Load all first level folder names from that folder. ie) output_ras2fim
@@ -162,7 +167,7 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
     Input
         - bucket_name: e.g xyz
         - src_path:  eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
-        - upload_skip_files: files that will not be uploaded to S3 (such as ras_unit_to_s3 log files)
+        - skip_files: files that will not be uploaded to S3 (such as ras_unit_to_s3 log files)
         - unit_folder_name:  12030105_2276_230810
 
     """
@@ -172,11 +177,11 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
 
     # yes.. print
     print(
+        f"{cl.fore.SPRING_GREEN_2B}"
         "-- The intention is that only one unit (per huc/crs) output folder, usually the most current,"
         " is kept in the offical output_ras2fim folder. All unit folders in the s3 output_ras2fim"
-        " folder will be included for ras2releases, and duplicate unit folders are likely undesirable."
+        f" folder will be included for ras2releases.{cl.style.RESET}"
     )
-    print("")
 
     # ---------------
     # splits it a five part dictionary
@@ -210,7 +215,7 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
         if existing_name_dict["unit_folder_name"] == src_name_dict["unit_folder_name"]:
             # exact same folder name including date
             action = __ask_user_about_dup_folder_name(s3_existing_folder_name, bucket_name)
-            RLOG.debug(f"action is {action}")
+            # RLOG.debug(f"action is {action}")
 
         # An existing s3_folder has a newer or older date
         else:
@@ -222,20 +227,13 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
             action = __ask_user_about_different_date_folder_name(
                 unit_folder_name, bucket_name, existing_name_dict["unit_folder_name"], is_existing_older
             )
-            RLOG.debug(f"action is {action}")
+            # RLOG.debug(f"action is {action}")
 
         # --------------------------
         # Process the action  (aka we start the uploads to S3 and changes in S3)
-        if action == TRACKER_ACTIONS[2]:  # overwrite the pre-existing same named folder with the incoming
-            RLOG.debug(f"action is {TRACKER_ACTIONS[2]}")
-            #  version, we need to delete the original folder so we don't leave junk it int.
-            __overwrite_s3_existing_folder(
-                src_path, bucket_name, src_name_dict["unit_folder_name"], is_verbose
-            )
-
-        elif action == TRACKER_ACTIONS[1]:  # moved_to_arch
-            RLOG.debug(f"action is {TRACKER_ACTIONS[1]}")
+        if action == TRACKER_ACTIONS[1]:  # moved_to_arch
             # existing moved to archive, new one to output
+            # RLOG.debug(f"action is {TRACKER_ACTIONS[1]}")
 
             # We will change the name to add on "_BK_yymmdd_hhmm".
             #  eg) s3://xyz/output_ras2fim_archive/12030105_2276_230810_BK_230825_1406
@@ -256,12 +254,20 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
                 TRACKER_ACTIONS[0],
                 sv.S3_OUTPUT_RAS2FIM_FOLDER,
                 unit_folder_name,
-                upload_skip_files,
+                skip_files,
                 is_verbose,
             )
 
+        elif action == TRACKER_ACTIONS[2]:  # (overwriting_prev)
+            # overwrite the pre-existing same named folder with the incoming
+            #  version, we need to delete the original folder so we don't leave junk it int.
+            # RLOG.debug(f"action is {TRACKER_ACTIONS[2]}")
+            __overwrite_s3_existing_folder(
+                src_path, bucket_name, src_name_dict["unit_folder_name"], skip_files, is_verbose
+            )
+
         elif action == TRACKER_ACTIONS[3]:  # straight_to_arch
-            RLOG.debug(f"action is {TRACKER_ACTIONS[3]}")
+            # RLOG.debug(f"action is {TRACKER_ACTIONS[3]}")
             new_s3_folder_name = __adjust_folder_name_for_archive(unit_folder_name)
 
             # new incoming goes straight to archive
@@ -272,7 +278,7 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
                 TRACKER_ACTIONS[3],
                 sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER,
                 new_s3_folder_name,
-                upload_skip_files,
+                skip_files,
                 is_verbose,
             )
 
@@ -283,15 +289,20 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
         RLOG.lprint("+++++++++++++++++++++++++")
         RLOG.lprint("")
         msg = (
+            f"{cl.fore.SPRING_GREEN_2B}"
             "We have detected multiple previously existing s3 folders with the same HUC and CRS "
             f"as the new incoming folder name of {unit_folder_name} at "
             f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}.\n\n"
             "All previously existing folders with this HUC and CRS will be moved to the archive"
-            " folder, then the new incoming unit will be uploaded to outputs.\n\n"
-            "Do you want to continue?\n\n"
-            "   -- Type 'continue' if you want to move existing s3 folders and upload the new one.\n"
-            "   -- Type 'abort' to stop the program.\n"
-            "  ?="
+            f" folder, then the new incoming unit will be uploaded to outputs.\n\n{cl.style.RESET}"
+            f"{cl.fore.LIGHT_YELLOW}"
+            " Do you want to continue?\n\n"
+            f"{cl.style.RESET}"
+            f"   -- Type {cl.fore.SPRING_GREEN_2B}'continue'{cl.style.RESET}"
+            "  if you want to move existing s3 folder(s) and upload the new one.\n"
+            f"   -- Type {cl.fore.SPRING_GREEN_2B}'abort'{cl.style.RESET}"
+            " to stop the program.\n"
+            f"{cl.fore.LIGHT_YELLOW}  ?={cl.style.RESET}"
         )
 
         resp = input(msg).lower()
@@ -323,7 +334,7 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
             TRACKER_ACTIONS[0],
             sv.S3_OUTPUT_RAS2FIM_FOLDER,
             unit_folder_name,
-            upload_skip_files,
+            skip_files,
             is_verbose,
         )
 
@@ -336,28 +347,34 @@ def __process_upload(bucket_name, src_path, unit_folder_name, upload_skip_files,
             TRACKER_ACTIONS[0],
             sv.S3_OUTPUT_RAS2FIM_FOLDER,
             unit_folder_name,
-            upload_skip_files,
+            skip_files,
             is_verbose,
         )
 
 
 ####################################################################
+# Unit folder already exists in outputs
 # Note: There is enough differnce that I wanted a seperate function for this scenario
 def __ask_user_about_dup_folder_name(unit_folder_name, bucket_name):
     print()
     print("*********************")
 
     msg = (
+        f"{cl.fore.SPRING_GREEN_2B}"
         f"You have requested to upload a unit folder named {unit_folder_name}."
         " However, a unit folder of the exact same name already exists at"
         f" s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}.\n"
         "Ensure that you or other staff have not uploaded the same unit folder (huc_crs_date).\n\n"
-        "   -- Type 'overwrite' if you want to overwrite the current folder.\n"
+        f"{cl.style.RESET}"
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'overwrite'{cl.style.RESET}"
+        " if you want to overwrite the current folder.\n"
         "           Note: If you overwrite an existing folder, the s3 version will be deleted first,\n"
         "           then the new incoming folder will be loaded.\n"
-        "   -- Type 'archive' if you want to move the existing folder in to the archive folder.\n"
-        "   -- Type 'abort' to stop the program.\n"
-        "  ?="
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'archive'{cl.style.RESET}"
+        " if you want to move the existing folder in to the archive folder.\n"
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'abort'{cl.style.RESET}"
+        " to stop the program.\n"
+        f"{cl.fore.LIGHT_YELLOW}  ?={cl.style.RESET}"
     )
 
     resp = input(msg).lower()
@@ -366,7 +383,7 @@ def __ask_user_about_dup_folder_name(unit_folder_name, bucket_name):
         sys.exit(0)
     elif (resp) == "overwrite":
         action = TRACKER_ACTIONS[2]  # overwriting_prev
-        RLOG.lprint(f"\n.. You have selected {resp}. Folder will be overwritten.\n")
+        RLOG.lprint(f"\n.. You have selected {resp}\n")
 
     elif (resp) == "archive":
         action = TRACKER_ACTIONS[1]  # moved_to_arch
@@ -374,7 +391,6 @@ def __ask_user_about_dup_folder_name(unit_folder_name, bucket_name):
             f"\n.. You have selected {resp}. Existing folder will be moved to "
             f"s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_ARCHIVE_FOLDER}.\n"
         )
-
     else:
         RLOG.lprint(f"\n.. You have entered an invalid value of '{resp}'. Program stopped.\n")
         sys.exit(0)
@@ -395,6 +411,7 @@ def __ask_user_about_different_date_folder_name(
     print("*********************")
 
     msg = (
+        f"{cl.fore.SPRING_GREEN_2B}"
         f"You have requested to upload a unit folder named {src_unit_folder_name}."
         " However, a folder of the starting with the same huc and crs already exists as"
         f" s3://{bucket_name}/{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{existing_folder_name}.\n"
@@ -408,17 +425,20 @@ def __ask_user_about_different_date_folder_name(
     msg += (
         f"Only one can remain in the {sv.S3_OUTPUT_RAS2FIM_FOLDER} folder, the other can be moved"
         " to the archive folder.\n\n"
+        f"{cl.style.RESET}"
+        f"{cl.fore.LIGHT_YELLOW}"
         "... Which of the two do you want to move to archive?\n"
-    )
-    msg += (
-        "   -- Type 'incoming' to upload the incoming folder"
-        " straight into archives and keep the existing in outputs.\n"
-        "   -- Type 'existing' to move the existing one to the archive folder and"
-        " upload the incoming folder to outputs.\n"
-        "   -- Type 'abort' to stop the program.\n"
-        "  ?="
+        f"{cl.style.RESET}"
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'incoming'{cl.style.RESET}"
+        "  to upload the incoming folder straight into archives and keep the existing in outputs.\n"
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'existing'{cl.style.RESET}"
+        " to move the existing one to the archive folder and upload the incoming folder to outputs.\n"
+        f"   -- Type {cl.fore.SPRING_GREEN_2B}'abort'{cl.style.RESET}"
+        " to stop the program.\n"
+        f"{cl.fore.LIGHT_YELLOW}  ?={cl.style.RESET}"
     )
 
+    print()
     resp = input(msg).lower()
     if resp == "abort":
         RLOG.lprint(f"\n.. You have selected {resp}. Program stopped.\n")
@@ -453,7 +473,7 @@ def __upload_s3_folder(
     action,
     s3_folder_path,
     new_s3_folder_name,
-    upload_skip_files,
+    skip_files,
     is_verbose,
 ):
     """
@@ -468,13 +488,14 @@ def __upload_s3_folder(
              huc_crs_date:  eg. 12030202_102739_230810
         - action: What is happening. Best to use TRACKER_ACTIONS dict (ugly but workable for now)
         - s3_folder_path: eg. output_ras2fim  or output_ras2fim_archive
-        - new_s3_folder_name: eg. 12030202_102739_230810_BK_230825_1406. It may or may not in the process
-             of having a new folder names as it is being loaded, especially if an incoming upload folder
-             is going straight to archives (which is an option)
-        - upload_skip_files: ie) the wip local tracker file, ras_unit_to_s3 log file
+        - new_s3_folder_name: eg. 12030202_102739_230810_BK_230825_1406 if going to archive.
+             It may or may not in the process of having a new folder names as it is being loaded,
+             especially if an incoming upload folder is going straight to archives (which is an option)
+        - skip_files: Files that will not be uploaded. ie) the wip local tracker file,
+             ras_unit_to_s3 log file
     """
 
-    s3_sf.upload_folder_to_s3(src_path, bucket_name, s3_folder_path, new_s3_folder_name, upload_skip_files)
+    s3_sf.upload_folder_to_s3(src_path, bucket_name, s3_folder_path, new_s3_folder_name, skip_files)
 
     __add_record_to_tracker(
         bucket_name, src_path, orig_folder_name, action, new_s3_folder_name, s3_folder_path, is_verbose
@@ -515,7 +536,7 @@ def __move_s3_folder_to_archive(bucket_name, src_path, orig_folder_name, target_
 
 
 ####################################################################
-def __overwrite_s3_existing_folder(src_path, bucket_name, unit_folder_name, upload_skip_files, is_verbose):
+def __overwrite_s3_existing_folder(src_path, bucket_name, unit_folder_name, skip_files, is_verbose):
     """
     Overview:
         When the system sees the exact same S3 huc_crs_date combination in output_ras2fim,
@@ -528,7 +549,7 @@ def __overwrite_s3_existing_folder(src_path, bucket_name, unit_folder_name, uplo
         - src_path: eg. c:\ras2fim_data\output_ras2fim\12030202_102739_230810
         - bucket_name: {your bucket name}
         - unit_folder_name: eg. 12030202_102739_230810
-        - upload_skip_files: ie) the wip local tracker file, ras_unit_to_s3 log file
+        - skip_files: Files not to be uploaded ie) the wip local tracker file, ras_unit_to_s3 log file.
     """
     s3_folder_path = f"{sv.S3_OUTPUT_RAS2FIM_FOLDER}/{unit_folder_name}"
 
@@ -546,7 +567,7 @@ def __overwrite_s3_existing_folder(src_path, bucket_name, unit_folder_name, uplo
     RLOG.debug(f"Uploading {src_path} to {sv.S3_OUTPUT_RAS2FIM_FOLDER}")
 
     s3_sf.upload_folder_to_s3(
-        src_path, bucket_name, sv.S3_OUTPUT_RAS2FIM_FOLDER, unit_folder_name, upload_skip_files
+        src_path, bucket_name, sv.S3_OUTPUT_RAS2FIM_FOLDER, unit_folder_name, skip_files
     )
 
     # TRACKER_ACTIONS[2] = overwriting_prev
@@ -714,7 +735,6 @@ def __add_record_to_tracker(
 
     try:
         print()
-        RLOG.lprint("*********************")
         RLOG.lprint(f"Updating the s3 tracker file at {s3_path_to_tracker_file}")
 
         huc_crs_folder_dict = s3_sf.parse_unit_folder_name(orig_folder_name)
@@ -844,15 +864,15 @@ def __validate_input(src_path_to_unit_output_dir, s3_bucket_name):
     final_dir = os.path.join(rtn_varibles_dict["src_unit_full_path"], sv.R2F_OUTPUT_DIR_FINAL)
     if not os.path.exists(final_dir):
         raise ValueError(
-            f"Source unit 'final folder' not found at {final_dir}."
-            " Ensure ras2fim has been run to completion."
+            f"Source unit 'final' folder not found at {final_dir}."
+            " Ensure ras2fim has been run to completion and that the full path is submitted in args."
         )
 
     # check to see that the "final" directory isn't empty
     file_count = len(os.listdir(final_dir))
     if file_count == 0:
         raise ValueError(
-            f"Source unit 'final folder' at {final_dir}" " does not appear to have any files or folders."
+            f"Source unit 'final' folder at {final_dir} does not appear to have any files or folders."
         )
 
     # --------------------


### PR DESCRIPTION
During a recent other merge, ras_unit_to_s3 began failing to upload. Now fixed.

Note: This tools uses `multi-threading` and not `multi-proc`.

Closes #[199](https://github.com/NOAA-OWP/ras2fim/issues/199)

### Changes  
- `src`/`shared_validators.py`: corrected text.
- `tools`
    - `ras_unit_to_s3.py`: Fix upload bug which was based in the `skip_files` system which exempts some files from  uploading to S3. Also added color to console as questions are asked of the user (live input). 
    - `s3_shared_functions.py`:  Removed progress bars which don't work well now with RLOG. . Fixed the `skip_files` system. Added color in key screen outputs for readability. Added throttling on max number of CPU's for multi-thread.

### Testing
- Tried every combination based on live screen user inputs. 
 **NOTE: All tests done against ras2fim-dev and not the prod ras2fim bucket.**

Also watched the S3 `ras_output_tracker.csv` to ensure all S3 changes were recorded correctly.

### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Pre-commit executed and linting changes made.
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [ ] n/a - New functions are documented (with a description, list of inputs, and expected output)
- [ ] n/a - Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [ ] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
