### PR TITLE
[1pt] PR: fix the stream direction bug

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v2.0.beta.16 - 2024-01-11 - [PR#253](https://github.com/NOAA-OWP/ras2fim/pull/253)
+
+This PR closes the issues  #219 and #246 and fixes a bug in ras2fim Step 1 as elaborated in #219 . 
+
+### Background
+To improve the conflation accuracy in Step 2, the streamlines are cut in Step 1 by shortening the portion of the streams that are downstream of the most downstream cross section. The current code is valid only if a HEC-RAS model streamline has been digitized from upstream to downstream. However, there are many HEC-RAS models that the streamlines have been digitized from downstream to upstream (this will not impact the integrity of these 1D HEC-RAS models though). 
+
+This bug fix will evaluate if a stream has been digitized from upstream to downstream. If not, the stream linestring is reversed and then the current algorithm to shorten the streamline is applied. 
+
+### Changes  
+- `src/create_shapes_from_hecras.py`
+
+<br/><br/>
+
 ## v2.0.beta.15 - 2024-01-09 - [PR#250](https://github.com/NOAA-OWP/ras2fim/pull/250)
 
 With most V2 development being focused on figuring out the logic, we have let linting and code standards lapse. This get the files caught up for linting and moving forward, all PR's will be fully linted, styled, logging included.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v2.0.beta.16 - 2024-01-11 - [PR#253](https://github.com/NOAA-OWP/ras2fim/pull/253)
+## v2.0.beta.16 - 2024-01-12 - [PR#253](https://github.com/NOAA-OWP/ras2fim/pull/253)
 
 This PR closes the issues  #219 and #246 and fixes a bug in ras2fim Step 1 as elaborated in #219 . 
 


### PR DESCRIPTION
This PR closes the issues  #219 and #246 and fixes a bug in ras2fim Step 1 as elaborated in #219 . 

### Background
To improve the conflation accuracy in Step 2, the streamlines are cut in Step 1 by shortening the portion of the streams that are downstream of the most downstream cross section. The current code is valid only if a HEC-RAS model streamline has been digitized from upstream to downstream. However, there are many HEC-RAS models that the streamlines have been digitized from downstream to upstream (this will not impact the integrity of these 1D HEC-RAS models though). 

This bug fix will evaluate if a stream has been digitized from upstream to downstream. If not, the stream linestring is reversed and then the current algorithm to shorten the streamline is applied. 

 

### Changes  
- `src/create_shapes_from_hecras.py`


### Testing
Testing is done by running Step 1 script as below (for HUC8 12090301):
python   src\create_shapes_from_hecras.py 
**-i** Path_To_RAS_Models   
    **-o** Path_To_Output_Folder      
  **-p** EPSG:2277

For a sample of 1263 HEC-RAS models in 12090301, fixing the bug adds 93 miles of streamlines that were being ignored previously because of this bug. The new added streamlines are shown with red color. 
![image](https://github.com/NOAA-OWP/ras2fim/assets/124194814/d9154d51-f3f1-4178-9cae-660932720245)



### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Pre-commit executed and linting changes made.
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
