### PR TITLE
[1pt] PR: Create a dissolved domain polygon for conflated RAS models

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v2.0.beta.25 - 2024-02-07 - [PR#281](https://github.com/NOAA-OWP/ras2fim/pull/281)
+## v2.0.beta.26 - 2024-02-15 - [PR#281](https://github.com/NOAA-OWP/ras2fim/pull/281)
 
 This PR closes the issue #275.
 The changes on `src/create_model_domain_polygons.py` include:

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@ The changes on `src/create_model_domain_polygons.py` include:
 
 <br/><br/>
 
+
 ## v2.0.beta.25 - 2024-02-15 - [PR#282](https://github.com/NOAA-OWP/ras2fim/pull/282)
 
 This PR focuses on developing the 2nd-pass flow hec-ras run. The goal was to create 0.5-foot stage depth grids for every nwm feature-id. This prevents sudden jumps in water surface elevations at the lower end of rating curves.   

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,21 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v2.0.beta.25 - 2024-02-07 - [PR#281](https://github.com/NOAA-OWP/ras2fim/pull/281)
+
+This PR closes the issue #275.
+The changes on `src/create_model_domain_polygons.py` include:
+
+- The `-conflate` argument is now a required argument.
+- Now, two gpkg files are produced by this code. The user now specifies an output directory and the program creates below two gpkg output files in the directory:
+	- 'models_domain.gpkg'... In this file, each HEC-RAS model domain represented by a polygon geometry
+	- 'dissolved_conflated_models.gpkg'.... This file contains a single dissolved polygon only for conflated HEC-RAS models
+
+### Changes 
+- `src/create_model_domain_polygons.py` as described above.
+- `src/ras2fim.py`... Adjusted accordingly to the changes applied above.
+
+<br/><br/>
 
 ## v2.0.beta.24 - 2024-02-02 - [PR#264](https://github.com/NOAA-OWP/ras2fim/pull/264)
 

--- a/src/create_model_domain_polygons.py
+++ b/src/create_model_domain_polygons.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     # python create_model_domain_polygons.py
     #  -i "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\...
     #          01_shapes_from_hecras\cross_section_LN_from_ras.shp"
-    #  -o "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\final\models_domain\ cool"
+    #  -o "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\final\models_domain\"
     #  -conflate "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\...
     #        02_csv_shapes_from_conflation\12090301_stream_qc_fid_xs.csv"
     #  -name ras_path

--- a/src/create_model_domain_polygons.py
+++ b/src/create_model_domain_polygons.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     # python create_model_domain_polygons.py
     #  -i "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\...
     #          01_shapes_from_hecras\cross_section_LN_from_ras.shp"
-    #  -o "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\final\models_domain\models_domain.gpkg"
+    #  -o "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\final\models_domain\ cool"
     #  -conflate "C:\ras2fim_data\output_ras2fim\12090301_2277_240201\...
     #        02_csv_shapes_from_conflation\12090301_stream_qc_fid_xs.csv"
     #  -name ras_path

--- a/src/ras2fim.py
+++ b/src/ras2fim.py
@@ -425,11 +425,6 @@ def fn_run_ras2fim(
 
     # -------------------------------------------------
     if os.getenv("CREATE_RAS_DOMAIN_POLYGONS") == "True":
-        # TODO:
-        # V2: Jan 22, 2024: All we need is one big poly that cover the max extent of all features.
-        # This is required for GVAL.
-        # We might already have this covered by earlier steps now. Research required here.
-
         RLOG.lprint("")
         RLOG.notice("+++++++ Processing: STEP: Create polygons for HEC-RAS models domains +++++++")
         RLOG.lprint(f"Module Started: {sf.get_stnd_date()}")
@@ -447,12 +442,11 @@ def fn_run_ras2fim(
         # Also see note in __main__ of create_model_domain_polygons.py as a duplicate msg (more less)
         #  But even after just manually adding that folder it still fails when run from command line.
         output_polygon_dir = os.path.join(r2f_final_dir, sv.R2F_OUTPUT_DIR_DOMAIN_POLYGONS)
-        polygons_output_file_path = os.path.join(output_polygon_dir, "models_domain.gpkg")
         os.mkdir(output_polygon_dir)
 
         fn_make_domain_polygons(
             xsections_shp_file_path,
-            polygons_output_file_path,
+            output_polygon_dir,
             "ras_path",
             model_huc_catalog_path,
             conflation_csv_path,


### PR DESCRIPTION
This PR closes the issue #275. 
The changes on `src/create_model_domain_polygons.py` includes:
- The `-conflate` argument is now a required argument.  
- Now, two gpkg files are produced by this code. The user now specifies an output directory (when running ras2fim.py, the output directory is "`ras2fim_outputs\final\models_domain`") and the program creates below two gpkg output files in the directory:
      - 'models_domain.gpkg'... In this file, each HEC-RAS model domain represented by a polygon geometry 
      - 'dissolved_conflated_models.gpkg'.... This file contains a single dissolved polygon only for conflated HEC-RAS models
 

### Changes  

- `src/create_model_domain_polygons.py` as described above. 
- `src/ras2fim.py`... Adjusted accordingly to the changes applied above. 



### Testing
Successfully tested the code with and without the optional arguments of `-catalog` for a run with a sample of HEC-RAS models in 12090301.

### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Pre-commit executed and linting changes made.
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/doc/CHANGELOG.md) and/or [README](/README.md))
- [x] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
